### PR TITLE
refactor(api): optimize getblock call in fees handler

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -135,8 +135,10 @@ export const relayerFeeCapitalCostConfig: {
   )
 );
 
+export const MAINNET_BLOCK_TIME_SECONDS = 12;
+
 // If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet timestamp minus this buffer.
-export const DEFAULT_QUOTE_TIMESTAMP_BUFFER = 12 * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
+export const DEFAULT_QUOTE_TIMESTAMP_BUFFER = MAINNET_BLOCK_TIME_SECONDS * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
 
 // If `timestamp` is not passed into a suggested-fees query, then return the latest price rounded to
 // the nearest multiple of this value.

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -135,7 +135,8 @@ export const relayerFeeCapitalCostConfig: {
   )
 );
 
-// If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet block minus this buffer.
+// If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet block minus this buffer
+// rounded down to the nearest `QUOTE_BLOCK_PRECISION`th block interval. Can be overridden by env var `QUOTE_BLOCK_BUFFER`.
 export const DEFAULT_QUOTE_BLOCK_BUFFER = 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
 
 export const BLOCK_TAG_LAG = -1;

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -135,14 +135,8 @@ export const relayerFeeCapitalCostConfig: {
   )
 );
 
-export const MAINNET_BLOCK_TIME_SECONDS = 12;
-
-// If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet timestamp minus this buffer.
-export const DEFAULT_QUOTE_TIMESTAMP_BUFFER = MAINNET_BLOCK_TIME_SECONDS * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
-
-// If `timestamp` is not passed into a suggested-fees query, then return the latest price rounded to
-// the nearest multiple of this value.
-export const DEFAULT_QUOTE_TIMESTAMP_PRECISION = 5 * 60; // 5 minutes
+// If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet block minus this buffer.
+export const DEFAULT_QUOTE_BLOCK_BUFFER = 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
 
 export const BLOCK_TAG_LAG = -1;
 

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1155,6 +1155,7 @@ export function getBaseRewardsApr(
  * @param provider Provider to use for the calls.
  * @param calls the calls to make via multicall3. Each call includes a contract, function name, and args, so that
  * this function can encode them correctly.
+ * @param overrides Overrides to use for the multicall3 call.
  * @returns An array of the decoded results in the same order that they were passed in.
  */
 export async function callViaMulticall3(
@@ -1163,7 +1164,8 @@ export async function callViaMulticall3(
     contract: ethers.Contract;
     functionName: string;
     args?: any[];
-  }[]
+  }[],
+  overrides?: ethers.CallOverrides
 ): Promise<ethers.utils.Result[]> {
   const multicall3 = new ethers.Contract(
     MULTICALL3_ADDRESS,
@@ -1175,9 +1177,10 @@ export async function callViaMulticall3(
     callData: contract.interface.encodeFunctionData(functionName, args),
   }));
 
-  const [, results] = await (multicall3.callStatic.aggregate(inputs) as Promise<
-    [BigNumber, string[]]
-  >);
+  const [, results] = await (multicall3.callStatic.aggregate(
+    inputs,
+    overrides
+  ) as Promise<[BigNumber, string[]]>);
   return results.map((result, i) =>
     calls[i].contract.interface.decodeFunctionResult(
       calls[i].functionName,

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -4,9 +4,8 @@ import { ethers } from "ethers";
 import { type, assert, Infer, optional, string } from "superstruct";
 import {
   disabledL1Tokens,
-  DEFAULT_QUOTE_TIMESTAMP_BUFFER,
   DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
-  MAINNET_BLOCK_TIME_SECONDS,
+  DEFAULT_QUOTE_BLOCK_BUFFER,
 } from "./_constants";
 import { TypedVercelRequest } from "./_types";
 import {
@@ -55,10 +54,7 @@ const handler = async (
     query,
   });
   try {
-    const { QUOTE_TIMESTAMP_BUFFER, QUOTE_TIMESTAMP_PRECISION } = process.env;
-    const quoteTimeBuffer = QUOTE_TIMESTAMP_BUFFER
-      ? Number(QUOTE_TIMESTAMP_BUFFER)
-      : DEFAULT_QUOTE_TIMESTAMP_BUFFER;
+    const { QUOTE_BLOCK_BUFFER, QUOTE_BLOCK_PRECISION } = process.env;
 
     const provider = getProvider(HUB_POOL_CHAIN_ID);
     const hubPool = getHubPool(provider);
@@ -149,49 +145,49 @@ const handler = async (
 
     const latestBlock = await provider.getBlock("latest");
 
-    // Note: Add a buffer to "latest" timestamp so that it corresponds to a block older than HEAD.
+    // The actual `quoteTimestamp` will be derived from the `quoteBlockNumber` below. If the caller supplies a timestamp,
+    // we use the method `BlockFinder.getBlockForTimestamp` to find the block number for that timestamp. If the caller does
+    // not supply a timestamp, we generate a timestamp from the latest block number minus a buffer.
+    let quoteBlockNumber: number;
+
+    // Note: Add a buffer to "latest" block so that it corresponds to a block older than HEAD.
     // This is to improve relayer UX who have heightened risk of sending inadvertent invalid fills
     // for quote times right at HEAD (or worst, in the future of HEAD). If timestamp is supplied as
     // a query param, then no need to apply buffer.
+    const quoteBlockBuffer = QUOTE_BLOCK_BUFFER
+      ? Number(QUOTE_BLOCK_BUFFER)
+      : DEFAULT_QUOTE_BLOCK_BUFFER;
 
-    // If the caller did not supply a quote timestamp, generate one from the latest block number.
+    // If the caller did not supply a quote timestamp, generate one from the latest block number minus buffer.
     let parsedTimestamp = Number(timestamp);
-    let blockFinderHints;
     if (isNaN(parsedTimestamp)) {
-      // Round timestamp. Assuming that depositors use this timestamp as the `quoteTimestamp` will allow relayers
-      // to take advantage of cached blocklatest block number.for-timestamp values when computing LP fee %'s. Currently the relayer is assumed
+      // Round block number. Assuming that depositors use this timestamp as the `quoteTimestamp` will allow relayers
+      // to take advantage of cached block numbers for timestamp values when computing LP fee %'s. Currently the relayer is assumed
       // to first find the block for deposit's `quoteTimestamp` and then call `HubPool#liquidityUtilization` at that block
       // height to derive the LP fee. The expensive operation is finding a block for a timestamp and involves a binary search.
       // We can use rounding here to increase the chance that a deposit's quote timestamp is re-used, thereby
       // allowing relayers hit the cache more often when fetching a block for a timestamp.
-      // Divide by intended precision in seconds, round down to nearest integer, multiply by precision in seconds.
-      const precision = Number(QUOTE_TIMESTAMP_PRECISION ?? 1);
-      parsedTimestamp =
-        Math.floor((latestBlock.timestamp - quoteTimeBuffer) / precision) *
+      // Divide by intended precision in blocks, round down to nearest integer, multiply by precision in blocks.
+      const precision = Number(QUOTE_BLOCK_PRECISION ?? quoteBlockBuffer);
+      quoteBlockNumber =
+        Math.floor((latestBlock.number - quoteBlockBuffer) / precision) *
         precision;
-
-      const quoteTimeBufferInBlocks =
-        quoteTimeBuffer / MAINNET_BLOCK_TIME_SECONDS;
-      const highBlock = latestBlock.number - quoteTimeBufferInBlocks + 1;
-      const lowBlock = highBlock - 1;
-      blockFinderHints = {
-        highBlock,
-        lowBlock,
-      };
     }
+    // If the caller supplied a timestamp, find the block number for that timestamp. This branch adds a bit of latency
+    // to the response time as it requires a binary search to find the block number for the given timestamp.
+    else {
+      // Don't attempt to provide quotes for future timestamps.
+      if (parsedTimestamp > latestBlock.timestamp) {
+        throw new InputError("Invalid quote timestamp");
+      }
 
-    // Don't attempt to provide quotes for future timestamps.
-    if (parsedTimestamp > latestBlock.timestamp) {
-      throw new InputError("Invalid quote timestamp");
+      const blockFinder = new sdk.utils.BlockFinder(provider, [latestBlock]);
+      const { number: blockNumberForTimestamp } =
+        await blockFinder.getBlockForTimestamp(parsedTimestamp);
+      quoteBlockNumber = blockNumberForTimestamp;
     }
 
     const amount = ethers.BigNumber.from(amountInput);
-
-    const blockFinder = new sdk.utils.BlockFinder(provider, [latestBlock]);
-    const { number: blockTag } = await blockFinder.getBlockForTimestamp(
-      parsedTimestamp,
-      blockFinderHints
-    );
 
     const configStoreClient = new sdk.contracts.acrossConfigStore.Client(
       ENABLED_ROUTES.acrossConfigStoreAddress,
@@ -200,23 +196,27 @@ const handler = async (
 
     const baseCurrency = destinationChainId === 137 ? "matic" : "eth";
 
-    const [currentUt, nextUt, rateModel, tokenPrice] = await Promise.all([
-      hubPool.callStatic.liquidityUtilizationCurrent(l1Token, {
-        blockTag,
-      }),
-      hubPool.callStatic.liquidityUtilizationPostRelay(l1Token, amount, {
-        blockTag,
-      }),
-      configStoreClient.getRateModel(
-        l1Token,
-        {
-          blockTag,
-        },
-        computedOriginChainId,
-        destinationChainId
-      ),
-      getCachedTokenPrice(l1Token, baseCurrency),
-    ]);
+    const [currentUt, nextUt, rateModel, tokenPrice, quoteTimestamp] =
+      await Promise.all([
+        hubPool.callStatic.liquidityUtilizationCurrent(l1Token, {
+          blockTag: quoteBlockNumber,
+        }),
+        hubPool.callStatic.liquidityUtilizationPostRelay(l1Token, amount, {
+          blockTag: quoteBlockNumber,
+        }),
+        configStoreClient.getRateModel(
+          l1Token,
+          {
+            blockTag: quoteBlockNumber,
+          },
+          computedOriginChainId,
+          destinationChainId
+        ),
+        getCachedTokenPrice(l1Token, baseCurrency),
+        hubPool.getCurrentTime({
+          blockTag: quoteBlockNumber,
+        }),
+      ]);
     const lpFeePct = sdk.lpFeeCalculator.calculateRealizedLpFeePct(
       rateModel,
       currentUt,
@@ -255,9 +255,9 @@ const handler = async (
       relayFeePct: totalRelayFeePct.toString(), // capitalFeePct + gasFeePct + lpFeePct
       relayFeeTotal: totalRelayFee.toString(), // capitalFeeTotal + gasFeeTotal + lpFeeTotal
       lpFeePct: "0", // Note: lpFeePct is now included in relayFeePct. We set it to 0 here for backwards compatibility.
-      timestamp: parsedTimestamp.toString(),
+      timestamp: quoteTimestamp.toString(),
       isAmountTooLow: relayerFeeDetails.isAmountTooLow,
-      quoteBlock: blockTag.toString(),
+      quoteBlock: quoteBlockNumber.toString(),
       spokePoolAddress: getSpokePoolAddress(Number(computedOriginChainId)),
       // Note: v3's new fee structure. Below are the correct values for the new fee structure. The above `*Pct` and `*Total`
       // values are for backwards compatibility which will be removed in the future.

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -165,9 +165,7 @@ const handler = async (
       // We can use rounding here to increase the chance that a deposit's quote timestamp is re-used, thereby
       // allowing relayers hit the cache more often when fetching a block for a timestamp.
       // Divide by intended precision in seconds, round down to nearest integer, multiply by precision in seconds.
-      const precision = Number(
-        QUOTE_TIMESTAMP_PRECISION ?? DEFAULT_QUOTE_TIMESTAMP_BUFFER
-      );
+      const precision = Number(QUOTE_TIMESTAMP_PRECISION ?? 1);
       parsedTimestamp =
         Math.floor((latestBlock.timestamp - quoteTimeBuffer) / precision) *
         precision;

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -1,5 +1,4 @@
 import * as sdk from "@across-protocol/sdk-v2";
-import { BlockFinder } from "@uma/sdk";
 import { VercelResponse } from "@vercel/node";
 import { ethers } from "ethers";
 import { type, assert, Infer, optional, string } from "superstruct";
@@ -179,7 +178,7 @@ const handler = async (
 
     const amount = ethers.BigNumber.from(amountInput);
 
-    const blockFinder = new BlockFinder(provider.getBlock.bind(provider));
+    const blockFinder = new sdk.utils.BlockFinder(provider, [latestBlock]);
     const { number: blockTag } = await blockFinder.getBlockForTimestamp(
       parsedTimestamp
     );

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -267,7 +267,9 @@ const handler = async (
       relayFeePct: totalRelayFeePct.toString(), // capitalFeePct + gasFeePct + lpFeePct
       relayFeeTotal: totalRelayFee.toString(), // capitalFeeTotal + gasFeeTotal + lpFeeTotal
       lpFeePct: "0", // Note: lpFeePct is now included in relayFeePct. We set it to 0 here for backwards compatibility.
-      timestamp: quoteTimestamp.toString(),
+      timestamp: isNaN(parsedTimestamp)
+        ? quoteTimestamp.toString()
+        : parsedTimestamp.toString(),
       isAmountTooLow: relayerFeeDetails.isAmountTooLow,
       quoteBlock: quoteBlockNumber.toString(),
       spokePoolAddress: getSpokePoolAddress(Number(computedOriginChainId)),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@safe-global/safe-apps-provider": "^0.18.0",
     "@safe-global/safe-apps-sdk": "^8.1.0",
     "@sentry/react": "^7.37.2",
-    "@uma/sdk": "^0.22.2",
     "@vercel/kv": "^1.0.1",
     "@web3-onboard/coinbase": "^2.2.5",
     "@web3-onboard/core": "^2.21.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4526,20 +4526,6 @@
     retry-request "^5.0.0"
     teeny-request "^8.0.0"
 
-"@google-cloud/datastore@^6.6.0":
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/@google-cloud/datastore/-/datastore-6.6.2.tgz#0240869f942350b194e8c2eea6588b83f20c412c"
-  integrity sha512-gQxSusM1gREtUogVqtl/KuoFrstYns8ZxY3guso2Mg2eJ+ygJwWdxXmG23T+aSbzkofh2OF3Mz0p3a+0F9KoPg==
-  dependencies:
-    "@google-cloud/promisify" "^2.0.0"
-    arrify "^2.0.1"
-    concat-stream "^2.0.0"
-    extend "^3.0.2"
-    google-gax "^2.24.1"
-    is "^3.3.0"
-    split-array-stream "^2.0.0"
-    stream-events "^1.0.5"
-
 "@google-cloud/datastore@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/datastore/-/datastore-7.0.0.tgz#e026db7d12c773230abf9e6b391a6196ef3fb81b"
@@ -4636,14 +4622,6 @@
     teeny-request "^8.0.0"
     uuid "^8.0.0"
 
-"@grpc/grpc-js@~1.6.0":
-  version "1.6.12"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.6.12.tgz#20f710d8a8c5c396b2ae9530ba6c06b984614fdf"
-  integrity sha512-JmvQ03OTSpVd9JTlj/K3IWHSz4Gk/JMLUTtW7Zb0KvO1LcOYGATh5cNuRYzCAeDR3O8wq+q8FZe97eO9MBrkUw==
-  dependencies:
-    "@grpc/proto-loader" "^0.7.0"
-    "@types/node" ">=12.12.47"
-
 "@grpc/grpc-js@~1.7.0":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.7.3.tgz#f2ea79f65e31622d7f86d4b4c9ae38f13ccab99a"
@@ -4659,17 +4637,6 @@
   dependencies:
     "@grpc/proto-loader" "^0.7.0"
     "@types/node" ">=12.12.47"
-
-"@grpc/proto-loader@^0.6.12":
-  version "0.6.13"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.6.13.tgz#008f989b72a40c60c96cd4088522f09b05ac66bc"
-  integrity sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==
-  dependencies:
-    "@types/long" "^4.0.1"
-    lodash.camelcase "^4.3.0"
-    long "^4.0.0"
-    protobufjs "^6.11.3"
-    yargs "^16.2.0"
 
 "@grpc/proto-loader@^0.7.0":
   version "0.7.6"
@@ -9254,20 +9221,10 @@
     web3 "^1.6.0"
     winston "^3.2.1"
 
-"@uma/contracts-frontend@^0.3.2":
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.3.18.tgz#dc6afcfa401c07d8d08be53eff4a97ca8eb06c79"
-  integrity sha512-eneJdzpxe+UFAmZufL7MAnQ/gX1c9reU12iUpfcBcNscNDoQcHw82P4KTmzIQ2zqHvvnMmvE/uLOsZ5OXGGJBw==
-
 "@uma/contracts-frontend@^0.4.16":
   version "0.4.16"
   resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.4.16.tgz#47f90874800a64e046143eefee9614fcafa8ca5b"
   integrity sha512-2/0A7wTh2zEw8GjYZmydRmTtQDfUtRHrttU2E5w8dACDIMA5EYrAm+G/r67SYcrt7+cWUmsBmR9AZ0QR01zN2A==
-
-"@uma/contracts-node@^0.3.2":
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.18.tgz#40e053ff6bc66f7ae7ce6c5d203a3200cf9ed928"
-  integrity sha512-ENFYjvVnyplKZF1G5YxOfpm0Ob1nOKtKcwX+TtfOiQGLNMVed8azV8tTSAWlJG/5SZkekX9Y5xZSP5YfcmMj0A==
 
 "@uma/contracts-node@^0.4.0":
   version "0.4.4"
@@ -9331,22 +9288,6 @@
     ipfs-http-client "^49.0.2"
     mocha "^8.3.0"
     node-fetch "^2.6.1"
-
-"@uma/sdk@^0.22.2":
-  version "0.22.2"
-  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.22.2.tgz#260ca268ae54084d0bae45e38affc2043c79b902"
-  integrity sha512-mgfRW8ZH4WuzoYgiEB5JWWEQjzYgaD5hCdY/mleq2r0GS17RpHslWy0y/xfCoDpAhVlsidMWn2QknmSeQc/z9Q==
-  dependencies:
-    "@google-cloud/datastore" "^6.6.0"
-    "@types/lodash-es" "^4.17.5"
-    "@uma/contracts-frontend" "^0.3.2"
-    "@uma/contracts-node" "^0.3.2"
-    axios "^0.24.0"
-    bn.js "^4.11.9"
-    decimal.js "^10.3.1"
-    highland "^2.13.5"
-    immer "^9.0.7"
-    lodash-es "^4.17.21"
 
 "@uma/sdk@^0.34.1":
   version "0.34.1"
@@ -16843,7 +16784,7 @@ gaxios@^5.0.0, gaxios@^5.0.1:
     is-stream "^2.0.0"
     node-fetch "^2.6.7"
 
-gcp-metadata@^4.0.0, gcp-metadata@^4.2.0:
+gcp-metadata@^4.0.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-4.3.1.tgz#fb205fe6a90fef2fd9c85e6ba06e5559ee1eefa9"
   integrity sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==
@@ -17223,21 +17164,6 @@ globrex@^0.1.2:
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
-google-auth-library@^7.14.0:
-  version "7.14.1"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.14.1.tgz#e3483034162f24cc71b95c8a55a210008826213c"
-  integrity sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==
-  dependencies:
-    arrify "^2.0.0"
-    base64-js "^1.3.0"
-    ecdsa-sig-formatter "^1.0.11"
-    fast-text-encoding "^1.0.0"
-    gaxios "^4.0.0"
-    gcp-metadata "^4.2.0"
-    gtoken "^5.0.4"
-    jws "^4.0.0"
-    lru-cache "^6.0.0"
-
 google-auth-library@^8.0.1, google-auth-library@^8.0.2:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-8.7.0.tgz#e36e255baba4755ce38dded4c50f896cf8515e51"
@@ -17252,25 +17178,6 @@ google-auth-library@^8.0.1, google-auth-library@^8.0.2:
     gtoken "^6.1.0"
     jws "^4.0.0"
     lru-cache "^6.0.0"
-
-google-gax@^2.24.1:
-  version "2.30.5"
-  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-2.30.5.tgz#e836f984f3228900a8336f608c83d75f9cb73eff"
-  integrity sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==
-  dependencies:
-    "@grpc/grpc-js" "~1.6.0"
-    "@grpc/proto-loader" "^0.6.12"
-    "@types/long" "^4.0.0"
-    abort-controller "^3.0.0"
-    duplexify "^4.0.0"
-    fast-text-encoding "^1.0.3"
-    google-auth-library "^7.14.0"
-    is-stream-ended "^0.1.4"
-    node-fetch "^2.6.1"
-    object-hash "^3.0.0"
-    proto3-json-serializer "^0.1.8"
-    protobufjs "6.11.3"
-    retry-request "^4.0.0"
 
 google-gax@^3.0.1:
   version "3.5.2"
@@ -17312,13 +17219,6 @@ google-gax@^3.5.2:
     protobufjs "7.2.3"
     protobufjs-cli "1.1.1"
     retry-request "^5.0.0"
-
-google-p12-pem@^3.1.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.1.4.tgz#123f7b40da204de4ed1fbf2fd5be12c047fc8b3b"
-  integrity sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==
-  dependencies:
-    node-forge "^1.3.1"
 
 google-p12-pem@^4.0.0:
   version "4.0.1"
@@ -17432,15 +17332,6 @@ growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-
-gtoken@^5.0.4:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-5.3.2.tgz#deb7dc876abe002178e0515e383382ea9446d58f"
-  integrity sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==
-  dependencies:
-    gaxios "^4.0.0"
-    google-p12-pem "^3.1.3"
-    jws "^4.0.0"
 
 gtoken@^6.1.0:
   version "6.1.2"
@@ -23150,13 +23041,6 @@ prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-proto3-json-serializer@^0.1.8:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz#705ddb41b009dd3e6fcd8123edd72926abf65a34"
-  integrity sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==
-  dependencies:
-    protobufjs "^6.11.2"
-
 proto3-json-serializer@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-1.1.0.tgz#52d9c73b24d25ff925639e1e5a01ac883460149f"
@@ -23196,25 +23080,6 @@ protobufjs-cli@1.1.1:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@6.11.3, protobufjs@^6.10.2, protobufjs@^6.11.2, protobufjs@^6.11.3:
-  version "6.11.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
-  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
-    "@types/node" ">=13.7.0"
-    long "^4.0.0"
-
 protobufjs@7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.1.2.tgz#a0cf6aeaf82f5625bffcf5a38b7cd2a7de05890c"
@@ -23250,6 +23115,25 @@ protobufjs@7.2.3, protobufjs@^7.0.0:
     "@protobufjs/utf8" "^1.1.0"
     "@types/node" ">=13.7.0"
     long "^5.0.0"
+
+protobufjs@^6.10.2, protobufjs@^6.11.2:
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
+  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
 
 protocol-buffers-schema@^3.3.1:
   version "3.6.0"
@@ -24487,14 +24371,6 @@ retimer@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/retimer/-/retimer-2.0.0.tgz#e8bd68c5e5a8ec2f49ccb5c636db84c04063bbca"
   integrity sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg==
-
-retry-request@^4.0.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-4.2.2.tgz#b7d82210b6d2651ed249ba3497f07ea602f1a903"
-  integrity sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==
-  dependencies:
-    debug "^4.1.1"
-    extend "^3.0.2"
 
 retry-request@^5.0.0:
   version "5.0.2"


### PR DESCRIPTION
This PR implements the suggestion made by @pxrl [here](https://github.com/across-protocol/frontend-v2/pull/1000#pullrequestreview-1988379973) which removes the need to call `BlockFinder.getBlockForTimestamp` for the default case. This saves up ~ 3 sequential `getBlock` RPC calls which results in a 30-90ms speed-up. Also all `HubPool` contract calls are aggregated via mulitcall, which should decrease the opportunities for delayed RPC calls

Previously
![vercel](https://github.com/across-protocol/frontend-v2/assets/17645687/4c6529e3-830e-4775-9798-7ef5e314b297)

Now
![vercel after](https://github.com/across-protocol/frontend-v2/assets/17645687/c3ec7bda-44d8-484a-8b48-9d3dd2882db2)
