### PR TITLE
fix: default to empty object when using `overrides`

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1165,7 +1165,7 @@ export async function callViaMulticall3(
     functionName: string;
     args?: any[];
   }[],
-  overrides?: ethers.CallOverrides
+  overrides: ethers.CallOverrides = {}
 ): Promise<ethers.utils.Result[]> {
   const multicall3 = new ethers.Contract(
     MULTICALL3_ADDRESS,


### PR DESCRIPTION
When we use `overrides`, in the multicall it requires an empty object. If the argument is `undefined` it throws 
```
Error: too many arguments: passed to contract (count=2, expectedCount=1, code=UNEXPECTED_ARGUMENT, version=contracts/5.7.0)
```