### PR TITLE
fix(api): multicaller util

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1177,9 +1177,13 @@ export async function callViaMulticall3(
     callData: contract.interface.encodeFunctionData(functionName, args),
   }));
 
+  const inputsToMulticall: unknown[] = [inputs];
+  if (overrides !== undefined) {
+    inputsToMulticall.push(overrides);
+  }
+
   const [, results] = await (multicall3.callStatic.aggregate(
-    inputs,
-    overrides
+    ...inputsToMulticall
   ) as Promise<[BigNumber, string[]]>);
   return results.map((result, i) =>
     calls[i].contract.interface.decodeFunctionResult(


### PR DESCRIPTION
We should only prepend the overrides field to the multicaller client if it's defined.