### PR TITLE
fix: make /pools more robust

### DIFF
--- a/api/pools.ts
+++ b/api/pools.ts
@@ -48,7 +48,10 @@ const handler = async (
       message: "Response data",
       responseJson: responseData,
     });
-    response.setHeader("Cache-Control", "s-maxage=300");
+    response.setHeader(
+      "Cache-Control",
+      "s-maxage=300, stale-while-revalidate=300"
+    );
     response.status(200).json(responseData);
   } catch (error: unknown) {
     return handleErrorCondition("pools", response, logger, error);


### PR DESCRIPTION
This doesn't fix the issue with the Balancer pool timeouts but will probably reduce it on the UI. We still need to find a proper fix to somehow speed up the subgraph query 