### PR TITLE
feat(api): `GET /swap-quote` endpoint

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -11,4 +11,11 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v3.0.4
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          # Comma-separated list of GHSA IDs to allow.
+          # We allow @openzeppelin/contracts@3.4.1-solc-0.7-2 critical vulnerabilities
+          # because they are not exploitable in our usage of the package.
+          allow-ghsas: >
+            "GHSA-fg47-3c2x-m2wr,GHSA-88g8-f5mf-f5rj"

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -17,5 +17,4 @@ jobs:
           # Comma-separated list of GHSA IDs to allow.
           # We allow @openzeppelin/contracts@3.4.1-solc-0.7-2 critical vulnerabilities
           # because they are not exploitable in our usage of the package.
-          allow-ghsas: >
-            "GHSA-fg47-3c2x-m2wr,GHSA-88g8-f5mf-f5rj"
+          allow-ghsas: GHSA-fg47-3c2x-m2wr, GHSA-88g8-f5mf-f5rj

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,4 +1,4 @@
-name: 'Dependency Review'
+name: "Dependency Review"
 on: [pull_request]
 
 permissions:
@@ -8,9 +8,9 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout Repository'
+      - name: "Checkout Repository"
         uses: actions/checkout@v3
-      - name: 'Dependency Review'
+      - name: "Dependency Review"
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high

--- a/api/_dexes/1inch.ts
+++ b/api/_dexes/1inch.ts
@@ -1,0 +1,52 @@
+import axios from "axios";
+
+import { AcrossSwap, SwapQuoteAndCalldata } from "./types";
+import { getSwapAndBridgeAddress } from "./utils";
+
+const config = {
+  slippage: 1, // Maximum acceptable slippage percentage for the swap (e.g., 1 for 1%)
+};
+
+export async function get1inchQuoteAndCalldata(
+  swap: AcrossSwap
+): Promise<SwapQuoteAndCalldata> {
+  try {
+    const swapAndBridgeAddress = getSwapAndBridgeAddress(
+      "1inch",
+      swap.swapToken.chainId
+    );
+    const apiBaseUrl = `https://api.1inch.dev/swap/v6.0/${swap.swapToken.chainId}`;
+    const apiHeaders = {
+      Authorization: `Bearer ${process.env.ONEINCH_API_KEY}`,
+      accept: "application/json",
+    };
+
+    const swapParams = {
+      src: swap.swapToken.address,
+      dst: swap.acrossInputToken.address,
+      amount: swap.swapTokenAmount,
+      from: swapAndBridgeAddress,
+      slippage: config.slippage,
+      disableEstimate: true,
+      allowPartialFill: false,
+      receiver: swapAndBridgeAddress,
+    };
+
+    const response = await axios.get(`${apiBaseUrl}/swap`, {
+      headers: apiHeaders,
+      params: swapParams,
+    });
+
+    return {
+      minExpectedInputTokenAmount:
+        response.data.toAmount || response.data.dstAmount,
+      routerCalldata: response.data.tx.data,
+      value: response.data.tx.value,
+      swapAndBridgeAddress,
+      dex: "1inch",
+    };
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}

--- a/api/_dexes/1inch.ts
+++ b/api/_dexes/1inch.ts
@@ -3,50 +3,42 @@ import axios from "axios";
 import { AcrossSwap, SwapQuoteAndCalldata } from "./types";
 import { getSwapAndBridgeAddress } from "./utils";
 
-const config = {
-  slippage: 1, // Maximum acceptable slippage percentage for the swap (e.g., 1 for 1%)
-};
-
 export async function get1inchQuoteAndCalldata(
   swap: AcrossSwap
 ): Promise<SwapQuoteAndCalldata> {
-  try {
-    const swapAndBridgeAddress = getSwapAndBridgeAddress(
-      "1inch",
-      swap.swapToken.chainId
-    );
-    const apiBaseUrl = `https://api.1inch.dev/swap/v6.0/${swap.swapToken.chainId}`;
-    const apiHeaders = {
-      Authorization: `Bearer ${process.env.ONEINCH_API_KEY}`,
-      accept: "application/json",
-    };
+  const swapAndBridgeAddress = getSwapAndBridgeAddress(
+    "1inch",
+    swap.swapToken.chainId
+  );
+  const apiBaseUrl = `https://api.1inch.dev/swap/v6.0/${swap.swapToken.chainId}`;
+  const apiHeaders = {
+    Authorization: `Bearer ${process.env.ONEINCH_API_KEY}`,
+    accept: "application/json",
+  };
 
-    const swapParams = {
-      src: swap.swapToken.address,
-      dst: swap.acrossInputToken.address,
-      amount: swap.swapTokenAmount,
-      from: swapAndBridgeAddress,
-      slippage: config.slippage,
-      disableEstimate: true,
-      allowPartialFill: false,
-      receiver: swapAndBridgeAddress,
-    };
+  const swapParams = {
+    src: swap.swapToken.address,
+    dst: swap.acrossInputToken.address,
+    amount: swap.swapTokenAmount,
+    from: swapAndBridgeAddress,
+    slippage: swap.slippage,
+    disableEstimate: true,
+    allowPartialFill: false,
+    receiver: swapAndBridgeAddress,
+  };
 
-    const response = await axios.get(`${apiBaseUrl}/swap`, {
-      headers: apiHeaders,
-      params: swapParams,
-    });
+  const response = await axios.get(`${apiBaseUrl}/swap`, {
+    headers: apiHeaders,
+    params: swapParams,
+  });
 
-    return {
-      minExpectedInputTokenAmount:
-        response.data.toAmount || response.data.dstAmount,
-      routerCalldata: response.data.tx.data,
-      value: response.data.tx.value,
-      swapAndBridgeAddress,
-      dex: "1inch",
-    };
-  } catch (e) {
-    console.error(e);
-    throw e;
-  }
+  return {
+    minExpectedInputTokenAmount:
+      response.data.toAmount || response.data.dstAmount,
+    routerCalldata: response.data.tx.data,
+    value: response.data.tx.value,
+    swapAndBridgeAddress,
+    dex: "1inch",
+    slippage: swap.slippage,
+  };
 }

--- a/api/_dexes/1inch.ts
+++ b/api/_dexes/1inch.ts
@@ -27,7 +27,20 @@ export async function get1inchQuoteAndCalldata(
     receiver: swapAndBridgeAddress,
   };
 
-  const response = await axios.get(`${apiBaseUrl}/swap`, {
+  const response = await axios.get<
+    {},
+    {
+      // https://portal.1inch.dev/documentation/swap/swagger?method=get&path=%2Fv6.0%2F1%2Fswap
+      data: {
+        toAmount?: string;
+        dstAmount: string;
+        tx: {
+          data: string;
+          value: string;
+        };
+      };
+    }
+  >(`${apiBaseUrl}/swap`, {
     headers: apiHeaders,
     params: swapParams,
   });

--- a/api/_dexes/1inch.ts
+++ b/api/_dexes/1inch.ts
@@ -27,20 +27,15 @@ export async function get1inchQuoteAndCalldata(
     receiver: swapAndBridgeAddress,
   };
 
-  const response = await axios.get<
-    {},
-    {
-      // https://portal.1inch.dev/documentation/swap/swagger?method=get&path=%2Fv6.0%2F1%2Fswap
-      data: {
-        toAmount?: string;
-        dstAmount: string;
-        tx: {
-          data: string;
-          value: string;
-        };
-      };
-    }
-  >(`${apiBaseUrl}/swap`, {
+  const response = await axios.get<{
+    // https://portal.1inch.dev/documentation/swap/swagger?method=get&path=%2Fv6.0%2F1%2Fswap
+    toAmount?: string;
+    dstAmount: string;
+    tx: {
+      data: string;
+      value: string;
+    };
+  }>(`${apiBaseUrl}/swap`, {
     headers: apiHeaders,
     params: swapParams,
   });

--- a/api/_dexes/types.ts
+++ b/api/_dexes/types.ts
@@ -6,16 +6,16 @@ type Token = {
 };
 
 /**
- * @property `depositor` - The address of the depositor.
  * @property `swapToken` - Address of the token that will be swapped for acrossInputToken.
  * @property `acrossInputToken` - Address of the token that will be bridged via Across as the inputToken.
  * @property `swapTokenAmount` - The amount of swapToken to be swapped for acrossInputToken.
+ * @property `slippage` - The slippage tolerance for the swap in decimals, e.g. 1 for 1%.
  */
 export type AcrossSwap = {
-  depositor: string;
   swapToken: Token;
   acrossInputToken: Token;
   swapTokenAmount: string;
+  slippage: number;
 };
 
 export type SwapQuoteAndCalldata = {
@@ -24,4 +24,5 @@ export type SwapQuoteAndCalldata = {
   value: string;
   swapAndBridgeAddress: string;
   dex: string;
+  slippage: number;
 };

--- a/api/_dexes/types.ts
+++ b/api/_dexes/types.ts
@@ -1,4 +1,4 @@
-type Token = {
+export type Token = {
   address: string;
   decimals: number;
   symbol: string;
@@ -18,11 +18,13 @@ export type AcrossSwap = {
   slippage: number;
 };
 
+export type SupportedDex = "1inch" | "uniswap";
+
 export type SwapQuoteAndCalldata = {
   minExpectedInputTokenAmount: string;
   routerCalldata: string;
   value: string;
   swapAndBridgeAddress: string;
-  dex: string;
+  dex: SupportedDex;
   slippage: number;
 };

--- a/api/_dexes/types.ts
+++ b/api/_dexes/types.ts
@@ -1,0 +1,27 @@
+type Token = {
+  address: string;
+  decimals: number;
+  symbol: string;
+  chainId: number;
+};
+
+/**
+ * @property `depositor` - The address of the depositor.
+ * @property `swapToken` - Address of the token that will be swapped for acrossInputToken.
+ * @property `acrossInputToken` - Address of the token that will be bridged via Across as the inputToken.
+ * @property `swapTokenAmount` - The amount of swapToken to be swapped for acrossInputToken.
+ */
+export type AcrossSwap = {
+  depositor: string;
+  swapToken: Token;
+  acrossInputToken: Token;
+  swapTokenAmount: string;
+};
+
+export type SwapQuoteAndCalldata = {
+  minExpectedInputTokenAmount: string;
+  routerCalldata: string;
+  value: string;
+  swapAndBridgeAddress: string;
+  dex: string;
+};

--- a/api/_dexes/uniswap.ts
+++ b/api/_dexes/uniswap.ts
@@ -1,0 +1,194 @@
+import { ethers } from "ethers";
+import {
+  FeeAmount,
+  Pool,
+  Route,
+  SwapOptions,
+  SwapQuoter,
+  SwapRouter,
+  Trade,
+  computePoolAddress,
+} from "@uniswap/v3-sdk";
+import {
+  Currency,
+  CurrencyAmount,
+  Percent,
+  Token,
+  TradeType,
+} from "@uniswap/sdk-core";
+import JSBI from "jsbi";
+import IUniswapV3PoolABI from "@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json";
+
+import { callViaMulticall3, getProvider } from "../_utils";
+import { AcrossSwap, SwapQuoteAndCalldata } from "./types";
+import { getSwapAndBridgeAddress } from "./utils";
+
+const POOL_FACTORY_CONTRACT_ADDRESS =
+  "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+const QUOTER_CONTRACT_ADDRESS = "0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6";
+
+// TODO: Should this be hardcoded or configurable?
+const config = {
+  poolFee: FeeAmount.LOW,
+  slippageTolerance: new Percent(50, 10_000), // 50 bips, or 0.50%
+  deadline: Math.floor(Date.now() / 1000) + 60 * 20, // 20 minutes from the current Unix time
+};
+
+export async function getUniswapQuoteAndCalldata(
+  swap: AcrossSwap
+): Promise<SwapQuoteAndCalldata> {
+  try {
+    const swapAndBridgeAddress = getSwapAndBridgeAddress(
+      "uniswap",
+      swap.swapToken.chainId
+    );
+
+    const poolInfo = await getPoolInfo(swap);
+    const tokenA = new Token(
+      swap.swapToken.chainId,
+      swap.swapToken.address,
+      swap.swapToken.decimals
+    );
+    const tokenB = new Token(
+      swap.acrossInputToken.chainId,
+      swap.acrossInputToken.address,
+      swap.acrossInputToken.decimals
+    );
+    const pool = new Pool(
+      tokenA,
+      tokenB,
+      config.poolFee,
+      poolInfo.sqrtPriceX96.toString(),
+      poolInfo.liquidity.toString(),
+      poolInfo.tick
+    );
+
+    const swapRoute = new Route([pool], tokenA, tokenB);
+
+    const amountOut = await getOutputQuote(swap, swapRoute);
+
+    const uncheckedTrade = Trade.createUncheckedTrade({
+      route: swapRoute,
+      inputAmount: CurrencyAmount.fromRawAmount(tokenA, swap.swapTokenAmount),
+      outputAmount: CurrencyAmount.fromRawAmount(
+        tokenB,
+        JSBI.BigInt(amountOut)
+      ),
+      tradeType: TradeType.EXACT_INPUT,
+    });
+
+    const options: SwapOptions = {
+      slippageTolerance: config.slippageTolerance,
+      deadline: config.deadline,
+      recipient: swapAndBridgeAddress,
+    };
+
+    const methodParameters = SwapRouter.swapCallParameters(
+      [uncheckedTrade],
+      options
+    );
+
+    return {
+      minExpectedInputTokenAmount: ethers.utils
+        .parseUnits(
+          uncheckedTrade.minimumAmountOut(options.slippageTolerance).toExact(),
+          swap.acrossInputToken.decimals
+        )
+        .toString(),
+      routerCalldata: methodParameters.calldata,
+      value: ethers.BigNumber.from(methodParameters.value).toString(),
+      swapAndBridgeAddress,
+      dex: "uniswap",
+    };
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}
+
+async function getOutputQuote(
+  swap: AcrossSwap,
+  route: Route<Currency, Currency>
+) {
+  const provider = getProvider(route.chainId);
+
+  const { calldata } = SwapQuoter.quoteCallParameters(
+    route,
+    CurrencyAmount.fromRawAmount(
+      new Token(
+        swap.swapToken.chainId,
+        swap.swapToken.address,
+        swap.swapToken.decimals
+      ),
+      swap.swapTokenAmount
+    ),
+    TradeType.EXACT_INPUT
+  );
+
+  const quoteCallReturnData = await provider.call({
+    to: QUOTER_CONTRACT_ADDRESS,
+    data: calldata,
+  });
+
+  return ethers.utils.defaultAbiCoder.decode(["uint256"], quoteCallReturnData);
+}
+
+async function getPoolInfo({
+  swapToken,
+  acrossInputToken,
+}: AcrossSwap): Promise<{
+  token0: string;
+  token1: string;
+  fee: number;
+  tickSpacing: number;
+  sqrtPriceX96: ethers.BigNumber;
+  liquidity: ethers.BigNumber;
+  tick: number;
+}> {
+  const provider = getProvider(swapToken.chainId);
+  const poolContract = new ethers.Contract(
+    computePoolAddress({
+      factoryAddress: POOL_FACTORY_CONTRACT_ADDRESS,
+      tokenA: new Token(
+        swapToken.chainId,
+        swapToken.address,
+        swapToken.decimals
+      ),
+      tokenB: new Token(
+        acrossInputToken.chainId,
+        acrossInputToken.address,
+        acrossInputToken.decimals
+      ),
+      fee: FeeAmount.LOW,
+    }),
+    IUniswapV3PoolABI.abi,
+    provider
+  );
+
+  const poolMethods = [
+    "token0",
+    "token1",
+    "fee",
+    "tickSpacing",
+    "liquidity",
+    "slot0",
+  ];
+  const [token0, token1, fee, tickSpacing, liquidity, slot0] =
+    await callViaMulticall3(
+      provider,
+      poolMethods.map((method) => ({
+        contract: poolContract,
+        functionName: method,
+      }))
+    );
+
+  return {
+    token0: token0 as unknown as string,
+    token1: token1 as unknown as string,
+    fee: fee as unknown as number,
+    tickSpacing: tickSpacing as unknown as number,
+    liquidity: liquidity as unknown as ethers.BigNumber,
+    sqrtPriceX96: slot0[0] as unknown as ethers.BigNumber,
+    tick: slot0[1] as unknown as number,
+  };
+}

--- a/api/_dexes/uniswap.ts
+++ b/api/_dexes/uniswap.ts
@@ -67,8 +67,13 @@ export async function getUniswapQuoteAndCalldata(
   });
 
   const options: SwapOptions = {
-    slippageTolerance: new Percent(swap.slippage, 100),
-    deadline: Math.floor(Date.now() / 1000) + 60 * 20, // 20 minutes from the current Unix time,
+    slippageTolerance: new Percent(
+      // max. slippage decimals is 2
+      Number(swap.slippage.toFixed(2)) * 100,
+      10_000
+    ),
+    // 20 minutes from the current Unix time
+    deadline: Math.floor(Date.now() / 1000) + 60 * 20,
     recipient: swapAndBridgeAddress,
   };
 

--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -12,6 +12,7 @@ export class UnsupportedDexOnChain extends Error {
   }
 }
 
+// TODO: use correct addresses
 export const swapAndBridgeAddresses = {
   uniswap: {
     [CHAIN_IDs.POLYGON]: "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",

--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -1,0 +1,39 @@
+import { CHAIN_IDs } from "../_constants";
+
+export class UnsupportedDex extends Error {
+  constructor(dex: string) {
+    super(`DEX/Aggregator ${dex} not supported`);
+  }
+}
+
+export class UnsupportedDexOnChain extends Error {
+  constructor(chainId: number, dex: string) {
+    super(`DEX/Aggregator ${dex} not supported on chain ${chainId}`);
+  }
+}
+
+export const swapAndBridgeAddresses = {
+  uniswap: {
+    [CHAIN_IDs.POLYGON]: "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+  },
+  "1inch": {
+    [CHAIN_IDs.POLYGON]: "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+  },
+} as const;
+
+export const swapAndBridgeDexes = Object.keys(swapAndBridgeAddresses);
+
+export function getSwapAndBridgeAddress(
+  dex: keyof typeof swapAndBridgeAddresses,
+  chainId: number
+) {
+  if (!swapAndBridgeDexes.includes(dex)) {
+    throw new UnsupportedDex(dex);
+  }
+
+  const address = swapAndBridgeAddresses[dex]?.[chainId];
+  if (!address) {
+    throw new UnsupportedDexOnChain(chainId, dex);
+  }
+  return address;
+}

--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -1,4 +1,4 @@
-import { CHAIN_IDs } from "../_constants";
+import { ENABLED_ROUTES } from "../_utils";
 
 export class UnsupportedDex extends Error {
   constructor(dex: string) {
@@ -12,29 +12,24 @@ export class UnsupportedDexOnChain extends Error {
   }
 }
 
-// TODO: use correct addresses
-export const swapAndBridgeAddresses = {
-  uniswap: {
-    [CHAIN_IDs.POLYGON]: "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
-  },
-  "1inch": {
-    [CHAIN_IDs.POLYGON]: "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
-  },
-} as const;
+export const swapAndBridgeDexes = Object.keys(
+  ENABLED_ROUTES.swapAndBridgeAddresses
+);
 
-export const swapAndBridgeDexes = Object.keys(swapAndBridgeAddresses);
-
-export function getSwapAndBridgeAddress(
-  dex: keyof typeof swapAndBridgeAddresses,
-  chainId: number
-) {
-  if (!swapAndBridgeDexes.includes(dex)) {
+export function getSwapAndBridgeAddress(dex: string, chainId: number) {
+  if (!_isDexSupported(dex)) {
     throw new UnsupportedDex(dex);
   }
 
-  const address = swapAndBridgeAddresses[dex]?.[chainId];
+  const address = ENABLED_ROUTES.swapAndBridgeAddresses[dex]?.[chainId];
   if (!address) {
     throw new UnsupportedDexOnChain(chainId, dex);
   }
   return address;
+}
+
+function _isDexSupported(
+  dex: string
+): dex is keyof typeof ENABLED_ROUTES.swapAndBridgeAddresses {
+  return swapAndBridgeDexes.includes(dex);
 }

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1510,3 +1510,28 @@ export function sendResponse(
   );
   return response.status(statusCode).json(body);
 }
+
+export function isSwapRouteEnabled({
+  originChainId,
+  destinationChainId,
+  acrossInputTokenSymbol,
+  acrossOutputTokenSymbol,
+  swapTokenAddress,
+}: {
+  originChainId: number;
+  destinationChainId: number;
+  acrossInputTokenSymbol: string;
+  acrossOutputTokenSymbol: string;
+  swapTokenAddress: string;
+}) {
+  const swapRoute = ENABLED_ROUTES.swapRoutes.find((route) => {
+    return (
+      route.fromChain === originChainId &&
+      route.toChain === destinationChainId &&
+      route.fromTokenSymbol === acrossInputTokenSymbol &&
+      route.toTokenSymbol === acrossOutputTokenSymbol &&
+      route.swapTokenAddress.toLowerCase() === swapTokenAddress.toLowerCase()
+    );
+  });
+  return !!swapRoute;
+}

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1011,6 +1011,12 @@ export function positiveIntStr() {
   });
 }
 
+export function positiveFloatStr(maxValue?: number) {
+  return define<string>("positiveFloatStr", (value) => {
+    return Number(value) >= 0 && (maxValue ? Number(value) <= maxValue : true);
+  });
+}
+
 export function boolStr() {
   return define<string>("boolStr", (value) => {
     return value === "true" || value === "false";

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -297,7 +297,7 @@ export const getRouteDetails = (
   originChainId?: number,
   outputTokenAddress?: string
 ) => {
-  const inputToken = _getTokenByAddress(inputTokenAddress, originChainId);
+  const inputToken = getTokenByAddress(inputTokenAddress, originChainId);
 
   if (!inputToken) {
     throw new InputError(
@@ -312,7 +312,7 @@ export const getRouteDetails = (
     : inputToken.addresses[HUB_POOL_CHAIN_ID];
   const l1Token = isBridgedUsdc(inputToken.symbol)
     ? TOKEN_SYMBOLS_MAP.USDC
-    : _getTokenByAddress(l1TokenAddress, HUB_POOL_CHAIN_ID);
+    : getTokenByAddress(l1TokenAddress, HUB_POOL_CHAIN_ID);
 
   if (!l1Token) {
     throw new InputError("No L1 token found for given input token address");
@@ -347,7 +347,7 @@ export const getRouteDetails = (
   outputTokenAddress ??= inputToken.addresses[destinationChainId];
 
   const outputToken = outputTokenAddress
-    ? _getTokenByAddress(outputTokenAddress, destinationChainId)
+    ? getTokenByAddress(outputTokenAddress, destinationChainId)
     : undefined;
 
   if (!outputToken) {
@@ -395,7 +395,7 @@ export const getRouteDetails = (
   };
 };
 
-const _getTokenByAddress = (tokenAddress: string, chainId?: number) => {
+export const getTokenByAddress = (tokenAddress: string, chainId?: number) => {
   const [, token] =
     Object.entries(TOKEN_SYMBOLS_MAP).find(([_symbol, { addresses }]) =>
       chainId

--- a/api/swap-quote.ts
+++ b/api/swap-quote.ts
@@ -1,0 +1,131 @@
+import { VercelResponse } from "@vercel/node";
+import { assert, Infer, type, string } from "superstruct";
+import { ethers } from "ethers";
+
+import { TypedVercelRequest } from "./_types";
+import {
+  InputError,
+  getLogger,
+  getTokenByAddress,
+  handleErrorCondition,
+  positiveIntStr,
+  validAddress,
+} from "./_utils";
+import { getUniswapQuoteAndCalldata } from "./_dexes/uniswap";
+import { get1inchQuoteAndCalldata } from "./_dexes/1inch";
+
+const SwapQuoteQueryParamsSchema = type({
+  depositor: validAddress(),
+  swapToken: validAddress(),
+  acrossInputToken: validAddress(),
+  swapTokenAmount: string(),
+  originChainId: positiveIntStr(),
+});
+
+type SwapQuoteQueryParams = Infer<typeof SwapQuoteQueryParamsSchema>;
+
+const handler = async (
+  { query }: TypedVercelRequest<SwapQuoteQueryParams>,
+  response: VercelResponse
+) => {
+  const logger = getLogger();
+  logger.debug({
+    at: "SwapQuote",
+    message: "Query data",
+    query,
+  });
+  try {
+    assert(query, SwapQuoteQueryParamsSchema);
+
+    let {
+      depositor,
+      swapToken: swapTokenAddress,
+      acrossInputToken: acrossInputTokenAddress,
+      swapTokenAmount,
+      originChainId: _originChainId,
+    } = query;
+
+    swapTokenAddress = ethers.utils.getAddress(swapTokenAddress);
+    acrossInputTokenAddress = ethers.utils.getAddress(acrossInputTokenAddress);
+    const originChainId = parseInt(_originChainId);
+
+    const _swapToken = getTokenByAddress(swapTokenAddress, originChainId);
+    const _acrossInputToken = getTokenByAddress(
+      acrossInputTokenAddress,
+      originChainId
+    );
+
+    if (!_swapToken || !_acrossInputToken) {
+      throw new InputError(
+        `Unsupported ${
+          !_swapToken ? "swap" : "input"
+        } token on chain ${originChainId}`
+      );
+    }
+
+    const swapToken = {
+      address: swapTokenAddress,
+      decimals: _swapToken.decimals,
+      symbol: _swapToken.symbol,
+      chainId: originChainId,
+    };
+    const acrossInputToken = {
+      address: acrossInputTokenAddress,
+      decimals: _acrossInputToken.decimals,
+      symbol: _acrossInputToken.symbol,
+      chainId: originChainId,
+    };
+
+    // TODO: add retry and timeout logic?
+    const quoteResults = await Promise.allSettled([
+      getUniswapQuoteAndCalldata({
+        depositor,
+        swapToken,
+        acrossInputToken,
+        swapTokenAmount,
+      }),
+      get1inchQuoteAndCalldata({
+        depositor,
+        swapToken,
+        acrossInputToken,
+        swapTokenAmount,
+      }),
+    ]);
+
+    const settledResults = quoteResults.flatMap((result) =>
+      result.status === "fulfilled" ? result.value : []
+    );
+
+    console.log(settledResults);
+
+    if (settledResults.length === 0) {
+      throw new Error("No quote results available");
+    }
+
+    const bestQuote = settledResults.reduce((best, current) => {
+      if (
+        ethers.BigNumber.from(current.minExpectedInputTokenAmount).gt(
+          best.minExpectedInputTokenAmount
+        )
+      ) {
+        return current;
+      }
+      return best;
+    });
+
+    logger.debug({
+      at: "SwapQuote",
+      message: "Response data",
+      responseJson: bestQuote,
+    });
+    response.setHeader(
+      "Cache-Control",
+      "s-maxage=150, stale-while-revalidate=150"
+    );
+    response.status(200).json(bestQuote);
+  } catch (error: unknown) {
+    return handleErrorCondition("swap-quote", response, logger, error);
+  }
+};
+
+export default handler;

--- a/api/swap-quote.ts
+++ b/api/swap-quote.ts
@@ -4,7 +4,6 @@ import { ethers } from "ethers";
 
 import { TypedVercelRequest } from "./_types";
 import {
-  ENABLED_ROUTES,
   InputError,
   getLogger,
   getTokenByAddress,
@@ -13,6 +12,7 @@ import {
   positiveIntStr,
   validAddress,
   validateChainAndTokenParams,
+  isSwapRouteEnabled,
 } from "./_utils";
 import { getUniswapQuoteAndCalldata } from "./_dexes/uniswap";
 import { get1inchQuoteAndCalldata } from "./_dexes/1inch";
@@ -83,15 +83,12 @@ const handler = async (
     // Only allow whitelisted swap routes. Can be viewed in the
     // `src/data/routes_*.json` files under the `swapRoutes` key.
     if (
-      !ENABLED_ROUTES.swapRoutes.find((route) => {
-        return (
-          route.fromChain === originChainId &&
-          route.toChain === destinationChainId &&
-          route.fromTokenSymbol === acrossInputToken.symbol &&
-          route.toTokenSymbol === acrossOutputToken.symbol &&
-          route.swapTokenAddress.toLowerCase() ===
-            swapTokenAddress.toLowerCase()
-        );
+      !isSwapRouteEnabled({
+        originChainId,
+        destinationChainId,
+        acrossInputTokenSymbol: acrossInputToken.symbol,
+        acrossOutputTokenSymbol: acrossOutputToken.symbol,
+        swapTokenAddress,
       })
     ) {
       throw new InputError(`Unsupported swap route`);

--- a/api/swap-quote.ts
+++ b/api/swap-quote.ts
@@ -1,5 +1,5 @@
 import { VercelResponse } from "@vercel/node";
-import { assert, Infer, type, string, optional, number } from "superstruct";
+import { assert, Infer, type, string, optional } from "superstruct";
 import { ethers } from "ethers";
 
 import { TypedVercelRequest } from "./_types";

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@safe-global/safe-apps-provider": "^0.18.0",
     "@safe-global/safe-apps-sdk": "^8.1.0",
     "@sentry/react": "^7.37.2",
+    "@uniswap/sdk-core": "^4.2.0",
+    "@uniswap/v3-sdk": "^3.11.0",
     "@vercel/kv": "^1.0.1",
     "@web3-onboard/coinbase": "^2.2.5",
     "@web3-onboard/core": "^2.21.2",

--- a/scripts/generate-routes.ts
+++ b/scripts/generate-routes.ts
@@ -8,6 +8,12 @@ import { TOKEN_SYMBOLS_MAP } from "../api/_constants";
 
 const { getDeployedAddress } = sdkUtils;
 
+type Route = typeof enabledRoutes[keyof typeof enabledRoutes]["routes"][number];
+type ToChain = Route["toChains"][number];
+type ToToken = ToChain["tokens"][number];
+type SwapToken = ToChain["swapTokens"][number];
+type ValidTokenSymbol = keyof typeof TOKEN_SYMBOLS_MAP;
+
 const enabledRoutes = {
   [CHAIN_IDs.MAINNET]: {
     hubPoolChain: CHAIN_IDs.MAINNET,
@@ -39,6 +45,11 @@ const enabledRoutes = {
         CHAIN_IDs.LINEA,
       ],
     },
+    swapAndBridgeAddresses: {
+      "1inch": {
+        [CHAIN_IDs.POLYGON]: "0xa0f2ecc40c9b6f470aa7483814fb7afc2d5a7e73",
+      },
+    },
     routes: [
       {
         fromChain: CHAIN_IDs.MAINNET,
@@ -59,6 +70,7 @@ const enabledRoutes = {
               "SNX",
               "POOL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.POLYGON,
@@ -74,6 +86,7 @@ const enabledRoutes = {
               "USDT",
               "POOL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ARBITRUM,
@@ -88,6 +101,7 @@ const enabledRoutes = {
               "ACX",
               "USDT",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ZK_SYNC,
@@ -99,6 +113,7 @@ const enabledRoutes = {
               "WBTC",
               "DAI",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.BASE,
@@ -109,6 +124,7 @@ const enabledRoutes = {
               "DAI",
               "BAL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.LINEA,
@@ -120,6 +136,7 @@ const enabledRoutes = {
               "USDT",
               "WBTC",
             ],
+            swapTokens: [],
           },
         ],
       },
@@ -142,6 +159,7 @@ const enabledRoutes = {
               "SNX",
               "POOL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.POLYGON,
@@ -157,6 +175,7 @@ const enabledRoutes = {
               "USDT",
               "POOL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ARBITRUM,
@@ -171,10 +190,12 @@ const enabledRoutes = {
               "ACX",
               "USDT",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ZK_SYNC,
             tokens: ["WETH", "ETH", "USDC.e", "WBTC", "USDT", "DAI"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.BASE,
@@ -185,10 +206,12 @@ const enabledRoutes = {
               "DAI",
               "BAL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.LINEA,
             tokens: ["WETH", "ETH", "USDC.e", "USDT", "DAI", "WBTC"],
+            swapTokens: [],
           },
         ],
       },
@@ -209,6 +232,7 @@ const enabledRoutes = {
               "USDT",
               "POOL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.OPTIMISM,
@@ -223,6 +247,13 @@ const enabledRoutes = {
               "USDT",
               "POOL",
             ],
+            swapTokens: [
+              {
+                swapInputTokenSymbol: "USDC",
+                acrossInputTokenSymbol: "USDC.e",
+                acrossOutputTokenSymbol: "USDC.e",
+              },
+            ],
           },
           {
             chainId: CHAIN_IDs.ARBITRUM,
@@ -236,10 +267,12 @@ const enabledRoutes = {
               "ACX",
               "USDT",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ZK_SYNC,
             tokens: ["WETH", "USDC.e", "WBTC", "USDT", "DAI"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.BASE,
@@ -249,10 +282,12 @@ const enabledRoutes = {
               { inputTokenSymbol: "USDC.e", outputTokenSymbol: "USDbC" },
               "BAL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.LINEA,
             tokens: ["WETH", "USDC.e", "USDT", "DAI", "WBTC"],
+            swapTokens: [],
           },
         ],
       },
@@ -273,6 +308,7 @@ const enabledRoutes = {
               "ACX",
               "USDT",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.OPTIMISM,
@@ -287,6 +323,7 @@ const enabledRoutes = {
               "ACX",
               "USDT",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.POLYGON,
@@ -301,10 +338,12 @@ const enabledRoutes = {
               "ACX",
               "USDT",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ZK_SYNC,
             tokens: ["WBTC", "USDC.e", "WETH", "ETH", "USDT", "DAI"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.BASE,
@@ -315,10 +354,12 @@ const enabledRoutes = {
               "DAI",
               "BAL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.LINEA,
             tokens: ["WETH", "ETH", "USDC.e", "USDT", "DAI", "WBTC"],
+            swapTokens: [],
           },
         ],
       },
@@ -336,18 +377,22 @@ const enabledRoutes = {
               "USDT",
               "DAI",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.OPTIMISM,
             tokens: ["WETH", "ETH", "USDC.e", "WBTC", "USDT", "DAI"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ARBITRUM,
             tokens: ["WETH", "ETH", "USDC.e", "WBTC", "USDT", "DAI"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.POLYGON,
             tokens: ["WETH", "USDC.e", "WBTC", "USDT", "DAI"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.BASE,
@@ -357,10 +402,12 @@ const enabledRoutes = {
               { inputTokenSymbol: "USDC.e", outputTokenSymbol: "USDbC" },
               "DAI",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.LINEA,
             tokens: ["WETH", "ETH", "USDC.e", "USDT", "DAI", "WBTC"],
+            swapTokens: [],
           },
         ],
       },
@@ -377,6 +424,7 @@ const enabledRoutes = {
               "DAI",
               "BAL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.OPTIMISM,
@@ -387,6 +435,7 @@ const enabledRoutes = {
               "DAI",
               "BAL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.POLYGON,
@@ -397,6 +446,7 @@ const enabledRoutes = {
               "DAI",
               "BAL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ARBITRUM,
@@ -407,6 +457,7 @@ const enabledRoutes = {
               "DAI",
               "BAL",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ZK_SYNC,
@@ -416,6 +467,7 @@ const enabledRoutes = {
               "ETH",
               "DAI",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.LINEA,
@@ -425,6 +477,7 @@ const enabledRoutes = {
               { inputTokenSymbol: "USDbC", outputTokenSymbol: "USDC.e" },
               "DAI",
             ],
+            swapTokens: [],
           },
         ],
       },
@@ -442,22 +495,27 @@ const enabledRoutes = {
               "DAI",
               "WBTC",
             ],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.OPTIMISM,
             tokens: ["WETH", "ETH", "USDC.e", "USDT", "DAI", "WBTC"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.POLYGON,
             tokens: ["WETH", "ETH", "USDC.e", "USDT", "DAI", "WBTC"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ARBITRUM,
             tokens: ["WETH", "ETH", "USDC.e", "USDT", "DAI", "WBTC"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ZK_SYNC,
             tokens: ["USDC.e", "WETH", "ETH", "DAI"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.BASE,
@@ -467,6 +525,7 @@ const enabledRoutes = {
               { inputTokenSymbol: "USDC.e", outputTokenSymbol: "USDbC" },
               "DAI",
             ],
+            swapTokens: [],
           },
         ],
       },
@@ -489,6 +548,7 @@ const enabledRoutes = {
       address: sdkUtils.AddressZero,
       enabledChains: [],
     },
+    swapAndBridgeAddresses: {},
     routes: [
       {
         fromChain: CHAIN_IDs.SEPOLIA,
@@ -497,13 +557,16 @@ const enabledRoutes = {
           {
             chainId: CHAIN_IDs.BASE_SEPOLIA,
             tokens: ["WETH", "USDC"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.OPTIMISM_SEPOLIA,
             tokens: ["WETH", "USDC"],
+            swapTokens: [],
           },
           {
             chainId: CHAIN_IDs.ARBITRUM_SEPOLIA,
+            swapTokens: [],
             tokens: ["WETH"],
           },
         ],
@@ -514,6 +577,7 @@ const enabledRoutes = {
         toChains: [
           {
             chainId: CHAIN_IDs.SEPOLIA,
+            swapTokens: [],
             tokens: ["WETH", "USDC"],
           },
         ],
@@ -527,6 +591,7 @@ const enabledRoutes = {
         toChains: [
           {
             chainId: CHAIN_IDs.SEPOLIA,
+            swapTokens: [],
             tokens: ["WETH", "USDC"],
           },
         ],
@@ -540,6 +605,7 @@ const enabledRoutes = {
         toChains: [
           {
             chainId: CHAIN_IDs.SEPOLIA,
+            swapTokens: [],
             tokens: ["WETH"],
           },
         ],
@@ -566,54 +632,27 @@ function generateRoutes(hubPoolChainId = 1) {
     ),
     merkleDistributorAddress: utils.getAddress(config.merkleDistributorAddress),
     claimAndStakeAddress: utils.getAddress(config.claimAndStakeAddress),
-    routes: config.routes.flatMap((route) => {
-      return route.toChains.flatMap((toChain) => {
-        return toChain.tokens.map((token) => {
-          const inputTokenSymbol =
-            typeof token === "object" ? token.inputTokenSymbol : token;
-          const outputTokenSymbol =
-            typeof token === "object" ? token.outputTokenSymbol : token;
-          const inputTokenAddress =
-            TOKEN_SYMBOLS_MAP[inputTokenSymbol].addresses[route.fromChain];
-          const outputTokenAddress =
-            TOKEN_SYMBOLS_MAP[outputTokenSymbol].addresses[toChain.chainId];
-
-          if (!inputTokenAddress || !outputTokenAddress) {
-            const isInputMissing = !inputTokenAddress;
-            throw new Error(
-              `Could not find address for ${
-                isInputMissing ? "input" : "output"
-              } token ${
-                isInputMissing ? inputTokenSymbol : outputTokenSymbol
-              } on chain ${isInputMissing ? route.fromChain : toChain.chainId}`
-            );
-          }
-
-          const l1TokenAddress =
-            TOKEN_SYMBOLS_MAP[
-              isBridgedUsdc(inputTokenSymbol) ? "USDC" : inputTokenSymbol
-            ].addresses[hubPoolChainId];
-
-          if (!l1TokenAddress) {
-            throw new Error(
-              `Could not find L1 token address for ${inputTokenSymbol}`
-            );
-          }
-
-          return {
-            fromChain: route.fromChain,
-            toChain: toChain.chainId,
-            fromTokenAddress: utils.getAddress(inputTokenAddress),
-            toTokenAddress: utils.getAddress(outputTokenAddress),
-            fromSpokeAddress: utils.getAddress(route.fromSpokeAddress),
-            fromTokenSymbol: inputTokenSymbol,
-            toTokenSymbol: outputTokenSymbol,
-            isNative: token === TOKEN_SYMBOLS_MAP.ETH.symbol,
-            l1TokenAddress: utils.getAddress(l1TokenAddress),
-          };
-        });
-      });
-    }),
+    swapAndBridgeAddresses: Object.entries(
+      config.swapAndBridgeAddresses
+    ).reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key]: Object.entries(value).reduce(
+          (acc, [chainId, address]) => ({
+            ...acc,
+            [chainId]: utils.getAddress(address as string),
+          }),
+          {}
+        ),
+      }),
+      {}
+    ),
+    routes: config.routes.flatMap((route) =>
+      transformBridgeRoute(route, config.hubPoolChain)
+    ),
+    swapRoutes: config.routes.flatMap((route) =>
+      transformSwapRoute(route, config.hubPoolChain)
+    ),
     pools: config.pools,
     spokePoolVerifier: config.spokePoolVerifier,
   };
@@ -624,6 +663,121 @@ function generateRoutes(hubPoolChainId = 1) {
       parser: "json",
     })
   );
+}
+
+function transformBridgeRoute(route: Route, hubPoolChainId: number) {
+  return route.toChains.flatMap((toChain: ToChain) => {
+    return toChain.tokens.map((token: ToToken) => {
+      const inputTokenSymbol =
+        typeof token === "object" ? token.inputTokenSymbol : token;
+      const outputTokenSymbol =
+        typeof token === "object" ? token.outputTokenSymbol : token;
+
+      return transformToRoute(
+        route,
+        toChain,
+        inputTokenSymbol,
+        outputTokenSymbol,
+        hubPoolChainId
+      );
+    });
+  });
+}
+
+function transformSwapRoute(route: Route, hubPoolChainId: number) {
+  return route.toChains.flatMap((toChain: ToChain) => {
+    return toChain.swapTokens.map((token: SwapToken) => {
+      const {
+        swapInputTokenSymbol,
+        acrossInputTokenSymbol,
+        acrossOutputTokenSymbol,
+      } = token;
+
+      const swapInputToken = getTokenBySymbol(
+        swapInputTokenSymbol,
+        route.fromChain,
+        hubPoolChainId
+      );
+      const bridgeRoute = transformToRoute(
+        route,
+        toChain,
+        acrossInputTokenSymbol,
+        acrossOutputTokenSymbol,
+        hubPoolChainId
+      );
+
+      return {
+        ...bridgeRoute,
+        swapTokenAddress: swapInputToken.address,
+        swapTokenSymbol: swapInputToken.symbol,
+        swapTokenL1TokenAddress: swapInputToken.l1TokenAddress,
+      };
+    });
+  });
+}
+
+function transformToRoute(
+  route: Route,
+  toChain: ToChain,
+  inputTokenSymbol: ValidTokenSymbol,
+  outputTokenSymbol: ValidTokenSymbol,
+  hubPoolChainId: number
+) {
+  const inputToken = getTokenBySymbol(
+    inputTokenSymbol,
+    route.fromChain,
+    hubPoolChainId
+  );
+  const outputToken = getTokenBySymbol(
+    outputTokenSymbol,
+    toChain.chainId,
+    hubPoolChainId
+  );
+
+  if (inputToken.l1TokenAddress !== outputToken.l1TokenAddress) {
+    throw new Error("Mismatching L1 addresses");
+  }
+
+  return {
+    fromChain: route.fromChain,
+    toChain: toChain.chainId,
+    fromTokenAddress: inputToken.address,
+    toTokenAddress: outputToken.address,
+    fromSpokeAddress: utils.getAddress(route.fromSpokeAddress),
+    fromTokenSymbol: inputTokenSymbol,
+    toTokenSymbol: outputTokenSymbol,
+    isNative: inputTokenSymbol === TOKEN_SYMBOLS_MAP.ETH.symbol,
+    l1TokenAddress: inputToken.l1TokenAddress,
+  };
+}
+
+function getTokenBySymbol(
+  tokenSymbol: ValidTokenSymbol,
+  chainId: number,
+  l1ChainId: number
+) {
+  const tokenAddress = TOKEN_SYMBOLS_MAP[tokenSymbol]?.addresses[chainId];
+
+  if (!tokenAddress) {
+    throw new Error(
+      `Could not find address for ${tokenSymbol}  on chain ${chainId}`
+    );
+  }
+
+  const l1TokenAddress =
+    TOKEN_SYMBOLS_MAP[isBridgedUsdc(tokenSymbol) ? "USDC" : tokenSymbol]
+      ?.addresses[l1ChainId];
+
+  if (!l1TokenAddress) {
+    throw new Error(`Could not find L1 token address for ${tokenSymbol}`);
+  }
+
+  return {
+    chainId,
+    address: utils.getAddress(tokenAddress),
+    symbol: tokenSymbol,
+    l1TokenAddress: utils.getAddress(l1TokenAddress),
+  };
 }
 
 function isBridgedUsdc(tokenSymbol: string) {

--- a/scripts/generate-routes.ts
+++ b/scripts/generate-routes.ts
@@ -47,7 +47,10 @@ const enabledRoutes = {
     },
     swapAndBridgeAddresses: {
       "1inch": {
-        [CHAIN_IDs.POLYGON]: "0xa0f2ecc40c9b6f470aa7483814fb7afc2d5a7e73",
+        [CHAIN_IDs.POLYGON]: "0xA0f2ecC40C9B6f470aA7483814fB7AFc2D5a7E73",
+      },
+      uniswap: {
+        [CHAIN_IDs.POLYGON]: "0x0c5b2ffdf21503cb31e2063b2b606313b6139db9",
       },
     },
     routes: [

--- a/scripts/generate-routes.ts
+++ b/scripts/generate-routes.ts
@@ -47,10 +47,10 @@ const enabledRoutes = {
     },
     swapAndBridgeAddresses: {
       "1inch": {
-        [CHAIN_IDs.POLYGON]: "0xA0f2ecC40C9B6f470aA7483814fB7AFc2D5a7E73",
+        [CHAIN_IDs.POLYGON]: "0xf9735e425a36d22636ef4cb75c7a6c63378290ca",
       },
       uniswap: {
-        [CHAIN_IDs.POLYGON]: "0x0c5b2ffdf21503cb31e2063b2b606313b6139db9",
+        [CHAIN_IDs.POLYGON]: "0xc2dcb88873e00c9d401de2cbba4c6a28f8a6e2c2",
       },
     },
     routes: [

--- a/src/data/routes_11155111_0x14224e63716afAcE30C9a417E0542281869f7d9e.json
+++ b/src/data/routes_11155111_0x14224e63716afAcE30C9a417E0542281869f7d9e.json
@@ -7,6 +7,7 @@
   "acceleratingDistributorAddress": "0x0000000000000000000000000000000000000000",
   "merkleDistributorAddress": "0x0000000000000000000000000000000000000000",
   "claimAndStakeAddress": "0x0000000000000000000000000000000000000000",
+  "swapAndBridgeAddresses": {},
   "routes": [
     {
       "fromChain": 11155111,
@@ -119,6 +120,7 @@
       "l1TokenAddress": "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14"
     }
   ],
+  "swapRoutes": [],
   "pools": [],
   "spokePoolVerifier": {
     "address": "0x0000000000000000000000000000000000000000",

--- a/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
+++ b/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
@@ -7,6 +7,11 @@
   "acceleratingDistributorAddress": "0x9040e41eF5E8b281535a96D9a48aCb8cfaBD9a48",
   "merkleDistributorAddress": "0xE50b2cEAC4f60E840Ae513924033E753e2366487",
   "claimAndStakeAddress": "0x985e8A89Dd6Af8896Ef075c8dd93512433dc5829",
+  "swapAndBridgeAddresses": {
+    "1inch": {
+      "137": "0xA0f2ecC40C9B6f470aA7483814fB7AFc2D5a7E73"
+    }
+  },
   "routes": [
     {
       "fromChain": 1,
@@ -2988,6 +2993,22 @@
       "toTokenSymbol": "DAI",
       "isNative": false,
       "l1TokenAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+    }
+  ],
+  "swapRoutes": [
+    {
+      "fromChain": 137,
+      "toChain": 10,
+      "fromTokenAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "toTokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+      "fromSpokeAddress": "0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096",
+      "fromTokenSymbol": "USDC.e",
+      "toTokenSymbol": "USDC.e",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "swapTokenAddress": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+      "swapTokenSymbol": "USDC",
+      "swapTokenL1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     }
   ],
   "pools": [

--- a/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
+++ b/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
@@ -9,10 +9,10 @@
   "claimAndStakeAddress": "0x985e8A89Dd6Af8896Ef075c8dd93512433dc5829",
   "swapAndBridgeAddresses": {
     "1inch": {
-      "137": "0xA0f2ecC40C9B6f470aA7483814fB7AFc2D5a7E73"
+      "137": "0xF9735e425A36d22636EF4cb75c7a6c63378290CA"
     },
     "uniswap": {
-      "137": "0x0c5b2fFDF21503cb31e2063B2B606313B6139DB9"
+      "137": "0xC2dCB88873E00c9d401De2CBBa4C6A28f8A6e2c2"
     }
   },
   "routes": [

--- a/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
+++ b/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
@@ -10,6 +10,9 @@
   "swapAndBridgeAddresses": {
     "1inch": {
       "137": "0xA0f2ecC40C9B6f470aA7483814fB7AFc2D5a7E73"
+    },
+    "uniswap": {
+      "137": "0x0c5b2fFDF21503cb31e2063B2B606313B6139DB9"
     }
   },
   "routes": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,7 +3344,7 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
-"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.0.0-beta.146", "@ethersproject/abi@^5.0.10", "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.4.0", "@ethersproject/abi@^5.5.0", "@ethersproject/abi@^5.6.3", "@ethersproject/abi@^5.7.0":
+"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.0.0-beta.146", "@ethersproject/abi@^5.0.10", "@ethersproject/abi@^5.0.12", "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.4.0", "@ethersproject/abi@^5.5.0", "@ethersproject/abi@^5.6.3", "@ethersproject/abi@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
   integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
@@ -4151,7 +4151,7 @@
     "@ethersproject/sha2" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
-"@ethersproject/solidity@5.7.0", "@ethersproject/solidity@^5.4.0":
+"@ethersproject/solidity@5.7.0", "@ethersproject/solidity@^5.0.9", "@ethersproject/solidity@^5.4.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
   integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
@@ -5907,6 +5907,11 @@
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.3.tgz#6b076a7b751811b90fe3a172a7faeaa603e13a3f"
   integrity sha512-SXDRl7HKpl2WDoJpn7CK/M9U4Z8gNXDHHChAKh0Iz+Wew3wu6CmFYBeie3je8V0GSXZAIYYwUktSrnW/kwVPtg==
+
+"@openzeppelin/contracts@3.4.1-solc-0.7-2":
+  version "3.4.1-solc-0.7-2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
+  integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
 "@openzeppelin/contracts@3.4.2-solc-0.7":
   version "3.4.2-solc-0.7"
@@ -9384,12 +9389,36 @@
   resolved "https://registry.yarnpkg.com/@uniswap/lib/-/lib-4.0.1-alpha.tgz#2881008e55f075344675b3bca93f020b028fbd02"
   integrity sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==
 
+"@uniswap/sdk-core@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-4.2.0.tgz#9930f133baec9c1118d891ebf8fcba7f7efc153d"
+  integrity sha512-yXAMLHZRYYuh6KpN2nOlLTYBjGiopmI9WUB4Z0tyNkW4ZZub54cUt22eibpGbZAhRAMxclox9IPIs6wwrM3soQ==
+  dependencies:
+    "@ethersproject/address" "^5.0.2"
+    big.js "^5.2.2"
+    decimal.js-light "^2.5.0"
+    jsbi "^3.1.4"
+    tiny-invariant "^1.1.0"
+    toformat "^2.0.0"
+
+"@uniswap/swap-router-contracts@^1.2.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/swap-router-contracts/-/swap-router-contracts-1.3.1.tgz#0ebbb93eb578625618ed9489872de381f9c66fb4"
+  integrity sha512-mh/YNbwKb7Mut96VuEtL+Z5bRe0xVIbjjiryn+iMMrK2sFKhR4duk/86mEz0UO5gSx4pQIw9G5276P5heY/7Rg==
+  dependencies:
+    "@openzeppelin/contracts" "3.4.2-solc-0.7"
+    "@uniswap/v2-core" "^1.0.1"
+    "@uniswap/v3-core" "^1.0.0"
+    "@uniswap/v3-periphery" "^1.4.4"
+    dotenv "^14.2.0"
+    hardhat-watcher "^2.1.1"
+
 "@uniswap/v2-core@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@uniswap/v2-core/-/v2-core-1.0.0.tgz#e0fab91a7d53e8cafb5326ae4ca18351116b0844"
   integrity sha512-BJiXrBGnN8mti7saW49MXwxDBRFiWemGetE58q8zgfnPPzQKq55ADltEILqOt6VFZ22kVeVKbF8gVd8aY3l7pA==
 
-"@uniswap/v2-core@1.0.1":
+"@uniswap/v2-core@1.0.1", "@uniswap/v2-core@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@uniswap/v2-core/-/v2-core-1.0.1.tgz#af8f508bf183204779938969e2e54043e147d425"
   integrity sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==
@@ -9407,7 +9436,7 @@
   resolved "https://registry.yarnpkg.com/@uniswap/v3-core/-/v3-core-1.0.0.tgz#6c24adacc4c25dceee0ba3ca142b35adbd7e359d"
   integrity sha512-kSC4djMGKMHj7sLMYVnn61k9nu+lHjMIxgg9CDQT+s2QYLoA56GbSK9Oxr+qJXzzygbkrmuY6cwgP6cW2JXPFA==
 
-"@uniswap/v3-core@^1.0.0-rc.2":
+"@uniswap/v3-core@^1.0.0", "@uniswap/v3-core@^1.0.0-rc.2":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@uniswap/v3-core/-/v3-core-1.0.1.tgz#b6d2bdc6ba3c3fbd610bdc502395d86cd35264a0"
   integrity sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ==
@@ -9422,6 +9451,40 @@
     "@uniswap/v2-core" "1.0.1"
     "@uniswap/v3-core" "1.0.0"
     base64-sol "1.0.1"
+
+"@uniswap/v3-periphery@^1.0.1", "@uniswap/v3-periphery@^1.1.1", "@uniswap/v3-periphery@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@uniswap/v3-periphery/-/v3-periphery-1.4.4.tgz#d2756c23b69718173c5874f37fd4ad57d2f021b7"
+  integrity sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==
+  dependencies:
+    "@openzeppelin/contracts" "3.4.2-solc-0.7"
+    "@uniswap/lib" "^4.0.1-alpha"
+    "@uniswap/v2-core" "^1.0.1"
+    "@uniswap/v3-core" "^1.0.0"
+    base64-sol "1.0.1"
+
+"@uniswap/v3-sdk@^3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/v3-sdk/-/v3-sdk-3.11.0.tgz#328309fbafddd8c618b7b6850bb99cacf6733a79"
+  integrity sha512-gz6Q6SlN34AXvxhyz181F90D4OuIkxLnzBAucEzB9Fv3Z+3orHZY/SpGaD02nP1VsNQVu/DQvOsdkPUDGn1Y9Q==
+  dependencies:
+    "@ethersproject/abi" "^5.0.12"
+    "@ethersproject/solidity" "^5.0.9"
+    "@uniswap/sdk-core" "^4.2.0"
+    "@uniswap/swap-router-contracts" "^1.2.1"
+    "@uniswap/v3-periphery" "^1.1.1"
+    "@uniswap/v3-staker" "1.0.0"
+    tiny-invariant "^1.1.0"
+    tiny-warning "^1.0.3"
+
+"@uniswap/v3-staker@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/v3-staker/-/v3-staker-1.0.0.tgz#9a6915ec980852479dfc903f50baf822ff8fa66e"
+  integrity sha512-JV0Qc46Px5alvg6YWd+UIaGH9lDuYG/Js7ngxPit1SPaIP30AlVer1UYB7BRYeUVVxE+byUyIeN5jeQ7LLDjIw==
+  dependencies:
+    "@openzeppelin/contracts" "3.4.1-solc-0.7-2"
+    "@uniswap/v3-core" "1.0.0"
+    "@uniswap/v3-periphery" "^1.0.1"
 
 "@upstash/redis@1.25.1":
   version "1.25.1"
@@ -13817,6 +13880,11 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
+decimal.js-light@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
+
 decimal.js@^10.2.1, decimal.js@^10.3.1, decimal.js@^10.4.2:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
@@ -14271,6 +14339,11 @@ dotenv-expand@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
   integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
+
+dotenv@^14.2.0:
+  version "14.3.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-14.3.2.tgz#7c30b3a5f777c79a3429cb2db358eef6751e8369"
+  integrity sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==
 
 dotenv@^16.0.0:
   version "16.3.1"
@@ -17437,6 +17510,13 @@ hardhat-typechain@^0.3.5:
   resolved "https://registry.yarnpkg.com/hardhat-typechain/-/hardhat-typechain-0.3.5.tgz#8e50616a9da348b33bd001168c8fda9c66b7b4af"
   integrity sha512-w9lm8sxqTJACY+V7vijiH+NkPExnmtiQEjsV9JKD1KgMdVk2q8y+RhvU/c4B7+7b1+HylRUCxpOIvFuB3rE4+w==
 
+hardhat-watcher@^2.1.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hardhat-watcher/-/hardhat-watcher-2.5.0.tgz#3ee76c3cb5b99f2875b78d176207745aa484ed4a"
+  integrity sha512-Su2qcSMIo2YO2PrmJ0/tdkf+6pSt8zf9+4URR5edMVti6+ShI8T3xhPrwugdyTOFuyj8lKHrcTZNKUFYowYiyA==
+  dependencies:
+    chokidar "^3.5.3"
+
 hardhat@^2.12.7:
   version "2.12.7"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.12.7.tgz#d8de2dc32e9a2956d53cf26ef4cd5857e57a3138"
@@ -19608,6 +19688,11 @@ js2xmlparser@^4.0.2:
   integrity sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==
   dependencies:
     xmlcreate "^2.0.4"
+
+jsbi@^3.1.4:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-3.2.5.tgz#b37bb90e0e5c2814c1c2a1bcd8c729888a2e37d6"
+  integrity sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ==
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -26153,6 +26238,11 @@ tiny-invariant@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
   integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
 
+tiny-invariant@^1.1.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
 tiny-invariant@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
@@ -26241,6 +26331,11 @@ tocbot@^4.20.1:
   version "4.21.3"
   resolved "https://registry.yarnpkg.com/tocbot/-/tocbot-4.21.3.tgz#8172136dd0fc5233a74d32811c2efb2133542e26"
   integrity sha512-UKFkjz0nRB4s5WAeVnQJ3iIKmaKBbWDxzHYlRzJPZO7Doyp6v12nkJMN6T3HiMoQFHldvO1MZLAKRJqDMzkv2A==
+
+toformat@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/toformat/-/toformat-2.0.0.tgz#7a043fd2dfbe9021a4e36e508835ba32056739d8"
+  integrity sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==
 
 toggle-selection@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
Closes ACX-2016

We will use `epic/cctp` for testing, that's why the base branch for this PR is set to that.

Example request:
https://app-frontend-v3-git-swap-quote-endpoint-uma.vercel.app/api/swap-quote?depositor=0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D&acrossInputToken=0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174&swapTokenAmount=100000000&originChainId=137&destinationChainId=10&acrossOutputToken=0x7F5c764cBc14f9669B88837ca1490cCa17c31607&swapToken=0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359

Note that I enabled the following swap route for testing purposes:
- `Native USDC (Polygon)` swap `Bridged USDC.e (Polygon)` bridge `Bridged USDC.e (OP)`

I am aware that this is not a route we want to support when we launch, but the closest route I could think of that fits our use case.