### PR TITLE
feat: add token symbols to `/available-routes` response

### DIFF
--- a/api/available-routes.ts
+++ b/api/available-routes.ts
@@ -78,6 +78,8 @@ const handler = async (
       originToken: route.originToken,
       destinationChainId: route.destinationChainId,
       destinationToken: route.destinationToken,
+      originTokenSymbol: route.fromTokenSymbol,
+      destinationTokenSymbol: route.toTokenSymbol,
     }));
 
     // Two different explanations for how `stale-while-revalidate` works:


### PR DESCRIPTION
Requested by integrators to add token symbols to `/available-routes` response