### PR TITLE
feat: enable missing native/bridged usdc routes on sepolia

### DIFF
--- a/src/data/routes_11155111_0x14224e63716afAcE30C9a417E0542281869f7d9e.json
+++ b/src/data/routes_11155111_0x14224e63716afAcE30C9a417E0542281869f7d9e.json
@@ -38,6 +38,17 @@
     },
     {
       "fromChain": 11155111,
+      "toChain": 84532,
+      "fromTokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+      "toTokenAddress": "0xE634Ec56B73779eCFfa78109a653FA0aE33D243f",
+      "fromSpokeAddress": "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDbC",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
+      "fromChain": 11155111,
       "toChain": 11155420,
       "fromTokenAddress": "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
       "toTokenAddress": "0x4200000000000000000000000000000000000006",
@@ -55,6 +66,17 @@
       "fromSpokeAddress": "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662",
       "fromTokenSymbol": "USDC",
       "toTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
+      "fromChain": 11155111,
+      "toChain": 11155420,
+      "fromTokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+      "toTokenAddress": "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",
+      "fromSpokeAddress": "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDC.e",
       "isNative": false,
       "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
     },
@@ -92,6 +114,28 @@
       "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
     },
     {
+      "fromChain": 84532,
+      "toChain": 11155420,
+      "fromTokenAddress": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "toTokenAddress": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
+      "fromSpokeAddress": "0x82B564983aE7274c86695917BBf8C99ECb6F0F8F",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
+      "fromChain": 84532,
+      "toChain": 11155420,
+      "fromTokenAddress": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "toTokenAddress": "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",
+      "fromSpokeAddress": "0x82B564983aE7274c86695917BBf8C99ECb6F0F8F",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDC.e",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
       "fromChain": 11155420,
       "toChain": 11155111,
       "fromTokenAddress": "0x4200000000000000000000000000000000000006",
@@ -110,6 +154,28 @@
       "fromSpokeAddress": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
       "fromTokenSymbol": "USDC",
       "toTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
+      "fromChain": 11155420,
+      "toChain": 84532,
+      "fromTokenAddress": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
+      "toTokenAddress": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "fromSpokeAddress": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
+      "fromChain": 11155420,
+      "toChain": 84532,
+      "fromTokenAddress": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
+      "toTokenAddress": "0xE634Ec56B73779eCFfa78109a653FA0aE33D243f",
+      "fromSpokeAddress": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDbC",
       "isNative": false,
       "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
     },
@@ -141,6 +207,34 @@
       "swapTokenL1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
     },
     {
+      "fromChain": 84532,
+      "toChain": 11155420,
+      "fromTokenAddress": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "toTokenAddress": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
+      "fromSpokeAddress": "0x82B564983aE7274c86695917BBf8C99ECb6F0F8F",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+      "swapTokenAddress": "0xE634Ec56B73779eCFfa78109a653FA0aE33D243f",
+      "swapTokenSymbol": "USDbC",
+      "swapTokenL1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
+      "fromChain": 84532,
+      "toChain": 11155420,
+      "fromTokenAddress": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "toTokenAddress": "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",
+      "fromSpokeAddress": "0x82B564983aE7274c86695917BBf8C99ECb6F0F8F",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDC.e",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+      "swapTokenAddress": "0xE634Ec56B73779eCFfa78109a653FA0aE33D243f",
+      "swapTokenSymbol": "USDbC",
+      "swapTokenL1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
       "fromChain": 11155420,
       "toChain": 11155111,
       "fromTokenAddress": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
@@ -148,6 +242,34 @@
       "fromSpokeAddress": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
       "fromTokenSymbol": "USDC",
       "toTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+      "swapTokenAddress": "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",
+      "swapTokenSymbol": "USDC.e",
+      "swapTokenL1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
+      "fromChain": 11155420,
+      "toChain": 84532,
+      "fromTokenAddress": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
+      "toTokenAddress": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "fromSpokeAddress": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+      "swapTokenAddress": "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",
+      "swapTokenSymbol": "USDC.e",
+      "swapTokenL1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    },
+    {
+      "fromChain": 11155420,
+      "toChain": 84532,
+      "fromTokenAddress": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
+      "toTokenAddress": "0xE634Ec56B73779eCFfa78109a653FA0aE33D243f",
+      "fromSpokeAddress": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
+      "fromTokenSymbol": "USDC",
+      "toTokenSymbol": "USDbC",
       "isNative": false,
       "l1TokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
       "swapTokenAddress": "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",

--- a/src/views/Bridge/hooks/useSelectRoute.ts
+++ b/src/views/Bridge/hooks/useSelectRoute.ts
@@ -62,15 +62,15 @@ export function useSelectRoute() {
           inputTokenSymbol: selectedRoute.fromTokenSymbol,
           fromChain: selectedRoute.fromChain,
           toChain: selectedRoute.toChain,
+          swapTokenSymbol:
+            selectedRoute.type === "swap"
+              ? selectedRoute.swapTokenSymbol
+              : undefined,
         }) || initialRoute;
 
       setSelectedRoute(route);
     },
-    [
-      selectedRoute.fromChain,
-      selectedRoute.toChain,
-      selectedRoute.fromTokenSymbol,
-    ]
+    [selectedRoute]
   );
 
   const handleSelectFromChain = useCallback(

--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -233,7 +233,6 @@ export function findNextBestRoute(
     : undefined;
 
   route = findEnabledRoute(filter);
-  console.log("#1", route, filter);
 
   if (!route && equivalentInputTokenSymbols) {
     for (const equivalentTokenSymbol of equivalentInputTokenSymbols) {

--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -22,6 +22,7 @@ export type SelectedRoute =
 
 type RouteFilter = Partial<{
   inputTokenSymbol: string;
+  swapTokenSymbol: string;
   outputTokenSymbol: string;
   fromChain: number;
   toChain: number;
@@ -39,8 +40,8 @@ const swapRoutes = config.getSwapRoutes();
 
 const interchangeableTokenPairs: Record<string, string[]> = {
   USDC: ["USDbC", "USDC.e"],
-  "USDC.e": ["USDC", "USDbC"],
-  USDbC: ["USDC", "USDC.e"],
+  "USDC.e": ["USDbC", "USDC"],
+  USDbC: ["USDC.e", "USDC"],
   ETH: ["WETH"],
   WETH: ["ETH"],
 };
@@ -148,18 +149,42 @@ export function getInitialRoute(defaults: RouteFilter = {}) {
 export function findEnabledRoute(
   filter: RouteFilter = {}
 ): SelectedRoute | undefined {
-  const { inputTokenSymbol, outputTokenSymbol, fromChain, toChain } = filter;
+  const {
+    inputTokenSymbol,
+    outputTokenSymbol,
+    swapTokenSymbol,
+    fromChain,
+    toChain,
+  } = filter;
+
+  const commonRouteFilter = (route: Route | SwapRoute) =>
+    (outputTokenSymbol
+      ? route.toTokenSymbol.toUpperCase() === outputTokenSymbol.toUpperCase()
+      : true) &&
+    (fromChain ? route.fromChain === fromChain : true) &&
+    (toChain ? route.toChain === toChain : true);
+
+  // prioritize swap routes if `swapTokenSymbol` is provided
+  if (swapTokenSymbol) {
+    const swapRoute = swapRoutes.find(
+      (route) =>
+        route.swapTokenSymbol.toUpperCase() === swapTokenSymbol.toUpperCase() &&
+        commonRouteFilter(route)
+    );
+
+    if (swapRoute) {
+      return {
+        ...swapRoute,
+        type: "swap",
+      };
+    }
+  }
 
   const route = enabledRoutes.find(
     (route) =>
       (inputTokenSymbol
         ? route.fromTokenSymbol.toUpperCase() === inputTokenSymbol.toUpperCase()
-        : true) &&
-      (outputTokenSymbol
-        ? route.toTokenSymbol.toUpperCase() === outputTokenSymbol.toUpperCase()
-        : true) &&
-      (fromChain ? route.fromChain === fromChain : true) &&
-      (toChain ? route.toChain === toChain : true)
+        : true) && commonRouteFilter(route)
   );
 
   if (route) {
@@ -174,11 +199,7 @@ export function findEnabledRoute(
       (!inputTokenSymbol ||
         swapRoute.swapTokenSymbol.toUpperCase() ===
           inputTokenSymbol.toUpperCase()) &&
-      (!outputTokenSymbol ||
-        swapRoute.toTokenSymbol.toUpperCase() ===
-          outputTokenSymbol.toUpperCase()) &&
-      (!fromChain || swapRoute.fromChain === fromChain) &&
-      (!toChain || swapRoute.toChain === toChain)
+      commonRouteFilter(swapRoute)
   );
 
   if (swapRoute) {
@@ -198,6 +219,7 @@ export function findEnabledRoute(
 export function findNextBestRoute(
   priorityFilterKeys: (
     | "inputTokenSymbol"
+    | "swapTokenSymbol"
     | "outputTokenSymbol"
     | "fromChain"
     | "toChain"
@@ -211,6 +233,7 @@ export function findNextBestRoute(
     : undefined;
 
   route = findEnabledRoute(filter);
+  console.log("#1", route, filter);
 
   if (!route && equivalentInputTokenSymbols) {
     for (const equivalentTokenSymbol of equivalentInputTokenSymbols) {
@@ -226,7 +249,7 @@ export function findNextBestRoute(
   }
 
   if (!route) {
-    const allFilterKeys = ["inputTokenSymbol", "fromChain", "toChain"] as const;
+    const allFilterKeys = Object.keys(filter) as Array<keyof RouteFilter>;
     const nonPriorityFilterKeys = allFilterKeys.filter((key) =>
       priorityFilterKeys.includes(key)
     );


### PR DESCRIPTION
This enables missing USDC routes on Base and OP Sepolia:
- `normal bridge routes`
  - native USDC -> USDC.e/USDbC
- `swap routes`
  - USDC.e/USDbC -> native USDC
  - USDC.e/USDbC -> USDC.e/USDbC