### PR TITLE
feat: preserve bridge url query params when initiating new tx

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,3 +21,4 @@ export * from "./wait";
 export * from "./types";
 export * from "./defined";
 export * from "./network";
+export * from "./url";

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,24 @@
+export function getBridgeUrlWithQueryParams({
+  fromChainId,
+  toChainId,
+  inputTokenSymbol,
+  outputTokenSymbol,
+}: {
+  fromChainId: number;
+  toChainId: number;
+  inputTokenSymbol: string;
+  outputTokenSymbol?: string;
+}) {
+  const cleanParams = Object.entries({
+    from: fromChainId.toString(),
+    to: toChainId.toString(),
+    inputToken: inputTokenSymbol,
+    outputToken: outputTokenSymbol,
+  }).reduce((acc, [key, value]) => {
+    if (value) {
+      return { ...acc, [key]: value };
+    }
+    return acc;
+  }, {});
+  return "/bridge?" + new URLSearchParams(cleanParams).toString();
+}

--- a/src/views/DepositStatus/components/DepositStatusLowerCard.tsx
+++ b/src/views/DepositStatus/components/DepositStatusLowerCard.tsx
@@ -9,7 +9,7 @@ import {
   getReceiveTokenSymbol,
 } from "views/Bridge/utils";
 import { useEstimatedRewards } from "views/Bridge/hooks/useEstimatedRewards";
-import { getToken, COLORS } from "utils";
+import { getToken, COLORS, getBridgeUrlWithQueryParams } from "utils";
 import { useIsContractAddress } from "hooks/useIsContractAddress";
 
 import { EarnByLpAndStakingCard } from "./EarnByLpAndStakingCard";
@@ -124,7 +124,18 @@ export function DepositStatusLowerCard({
         </>
       )}
       <Divider />
-      <Button onClick={() => history.push("/bridge")}>
+      <Button
+        onClick={() =>
+          history.push(
+            getBridgeUrlWithQueryParams({
+              fromChainId,
+              toChainId,
+              inputTokenSymbol,
+              outputTokenSymbol,
+            })
+          )
+        }
+      >
         Initiate new transaction
       </Button>
     </>

--- a/src/views/DepositStatus/components/DepositTimesCard.tsx
+++ b/src/views/DepositStatus/components/DepositTimesCard.tsx
@@ -9,7 +9,7 @@ import { ReactComponent as ExternalLinkIcon } from "assets/icons/external-link-1
 import { ReactComponent as RefreshIcon } from "assets/icons/refresh.svg";
 
 import { Text, CardWrapper } from "components";
-import { getChainInfo, COLORS } from "utils";
+import { getChainInfo, COLORS, getBridgeUrlWithQueryParams } from "utils";
 import { useAmplitude } from "hooks";
 import { ampli } from "ampli";
 
@@ -71,7 +71,14 @@ export function DepositTimesCard({
             StatusIcon={<StyledLoadingIcon />}
           />
         ) : isDepositReverted ? (
-          <TryAgainButton to={tryAgainLink}>
+          <TryAgainButton
+            to={getBridgeUrlWithQueryParams({
+              fromChainId,
+              toChainId,
+              inputTokenSymbol,
+              outputTokenSymbol,
+            })}
+          >
             <Text color="warning">Try again</Text>
             <RefreshIcon />
           </TryAgainButton>


### PR DESCRIPTION
While QAing different deposit routes, it was a bit annoying that the query params from the previous deposit were not preserved.