### PR TITLE
feat: make default swap slippage configurable

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -854,3 +854,8 @@ export const vercelApiBaseUrl =
 
 export const bnUint32Max = utils.bnUint32Max;
 export const bnZero = utils.bnZero;
+
+// Swap slippage in %, 1 = 1%
+export const defaultSwapSlippage = Number(
+  process.env.REACT_APP_DEFAULT_SWAP_SLIPPAGE || 1
+);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -855,7 +855,7 @@ export const vercelApiBaseUrl =
 export const bnUint32Max = utils.bnUint32Max;
 export const bnZero = utils.bnZero;
 
-// Swap slippage in %, 1 = 1%
+// Swap slippage in %, 0.5 = 0.5%
 export const defaultSwapSlippage = Number(
-  process.env.REACT_APP_DEFAULT_SWAP_SLIPPAGE || 1
+  process.env.REACT_APP_DEFAULT_SWAP_SLIPPAGE || 0.5
 );

--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -11,13 +11,13 @@ import { useSelectRoute } from "./useSelectRoute";
 import { useTransferQuote, type TransferQuote } from "./useTransferQuote";
 import { useAmountInput } from "./useAmountInput";
 import { validateBridgeAmount } from "../utils";
+import { defaultSwapSlippage } from "utils";
 
 export function useBridge() {
   const [shouldUpdateQuote, setShouldUpdateQuote] = useState(true);
   const [usedTransferQuote, setUsedTransferQuote] = useState<TransferQuote>();
 
-  // default slippage of 0.5%
-  const [swapSlippage, setSwapSlippage] = useState(0.5);
+  const [swapSlippage, setSwapSlippage] = useState(defaultSwapSlippage);
 
   const { isConnected, chainId: walletChainId, account } = useConnection();
 


### PR DESCRIPTION
I noticed a few swaps that were reverting on Polygon. Probably due to too low slippage? But in case we want to change it dynamically, I prepared this PR to override via env var.