### PR TITLE
feat(domain-identifier): add domain identifier to txn calls

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -182,3 +182,7 @@ export const DEFAULT_RECOMMENDED_DEPOSIT_INSTANT_LIMITS = {
   [TOKEN_SYMBOLS_MAP.WETH.symbol]: "2",
   [TOKEN_SYMBOLS_MAP.USDC.symbol]: "5000",
 };
+
+export const EXTERNAL_DOMAIN_TO_BYTE_MAP: Record<string, string> = {
+  across: "0x0000",
+};

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -6,7 +6,7 @@ import {
   fixedPointAdjustment,
   referrerDelimiterHex,
 } from "./constants";
-import { tagAddress } from "./format";
+import { tagAcrossDomain, tagAddress } from "./format";
 import { getProvider } from "./providers";
 import { getFastFillTimeByRoute } from "./fill-times";
 import { getConfig, getCurrentTime } from "utils";
@@ -477,10 +477,11 @@ async function _tagRefAndSignTx(
   onNetworkMismatch?: NetworkMismatchHandler
 ) {
   // do not tag a referrer if data is not provided as a hex string.
-  tx.data =
+  tx.data = tagAcrossDomain(
     referrer && ethers.utils.isAddress(referrer)
       ? tagAddress(tx.data!, referrer, referrerDelimiterHex)
-      : tx.data;
+      : tx.data!
+  );
 
   // Last test to ensure that the tx is valid and that the signer
   // is connected to the correct chain.

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -195,6 +195,11 @@ export function tagString(dataHex: string, tagString: string) {
   return tagHex(dataHex, stringToHex(tagString));
 }
 
+// tags the hardcoded across chain reference
+export function tagAcrossDomain(dataHex: string) {
+  return tagHex(dataHex, "0x0000", "0x1DC0de");
+}
+
 // tags only an address
 export function tagAddress(
   dataHex: string,


### PR DESCRIPTION
Appends a domain identifier to the txn after the referrer identifier. If a provider references `domain` in the `build-deposit-tx` and we have a mapping then the endpoint will return calldata with the appended 4byte identifier.

Example Call:
```
/api/build-deposit-tx?amount=10000&token=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&destinationChainId=10&originChainId=1&recipient=0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D&relayerFeePct=5&quoteTimestamp=5&domain=across
```