### PR TITLE
feat: Across Lite support in /limits and /suggested-fees endpoints

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -169,7 +169,8 @@ const handler = async (
 
     let { liquidReserves } = multicallOutput[1];
     const [liteChainIdsEncoded] = multicallOutput[2];
-    const liteChainIds = JSON.parse(liteChainIdsEncoded);
+    const liteChainIds =
+      liteChainIdsEncoded === "" ? [] : JSON.parse(liteChainIdsEncoded);
     const routeInvolvesLiteChain = [
       computedOriginChainId,
       destinationChainId,
@@ -177,6 +178,12 @@ const handler = async (
 
     const transferBalances = fullRelayerBalances.map((balance, i) =>
       balance.add(fullRelayerMainnetBalances[i])
+    );
+
+    const bufferMultipliers = getLimitsBufferMultipliers(
+      l1Token.symbol,
+      computedOriginChainId,
+      destinationChainId
     );
 
     const minDeposit = ethers.BigNumber.from(relayerFeeDetails.minDeposit);

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -180,12 +180,6 @@ const handler = async (
       balance.add(fullRelayerMainnetBalances[i])
     );
 
-    const bufferMultipliers = getLimitsBufferMultipliers(
-      l1Token.symbol,
-      computedOriginChainId,
-      destinationChainId
-    );
-
     const minDeposit = ethers.BigNumber.from(relayerFeeDetails.minDeposit);
 
     // Normalise the environment-set USD minimum to units of the token being bridged.
@@ -198,7 +192,7 @@ const handler = async (
           )
           .mul(ethers.utils.parseUnits("1"))
           .div(tokenPriceUsd);
-    
+
     let maxDepositInstant = maxBN(
       ...fullRelayerBalances,
       ...transferRestrictedBalances
@@ -223,18 +217,17 @@ const handler = async (
     }
 
     const limitsBufferMultiplier = getLimitsBufferMultiplier(l1Token.symbol);
-    
+
     // Apply multipliers
-    const bufferedRecommendedDepositInstant =
-    limitsBufferMultiplier
+    const bufferedRecommendedDepositInstant = limitsBufferMultiplier
       .mul(maxDepositInstant)
       .div(sdk.utils.fixedPointAdjustment);
     const bufferedMaxDepositInstant = limitsBufferMultiplier
       .mul(maxDepositInstant)
       .div(sdk.utils.fixedPointAdjustment);
     const bufferedMaxDepositShortDelay = limitsBufferMultiplier
-    .mul(maxDepositShortDelay)
-    .div(sdk.utils.fixedPointAdjustment);
+      .mul(maxDepositShortDelay)
+      .div(sdk.utils.fixedPointAdjustment);
 
     const responseJson = {
       // Absolute minimum may be overridden by the environment.
@@ -243,12 +236,9 @@ const handler = async (
       // but still prevent users from depositing more than the `maxDepositShortDelay`,
       // only if buffer multiplier is set to 100%.
       maxDeposit: bufferedMaxDepositShortDelay.toString(),
-      maxDepositInstant: bufferedMaxDepositInstant
-        .toString(),
-      maxDepositShortDelay: bufferedMaxDepositShortDelay
-        .toString(),
-      recommendedDepositInstant:bufferedRecommendedDepositInstant
-        .toString(),
+      maxDepositInstant: bufferedMaxDepositInstant.toString(),
+      maxDepositShortDelay: bufferedMaxDepositShortDelay.toString(),
+      recommendedDepositInstant: bufferedRecommendedDepositInstant.toString(),
     };
     logger.debug({
       at: "Limits",

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -235,7 +235,11 @@ const handler = async (
       // We set `maxDeposit` equal to `maxDepositShortDelay` to be backwards compatible
       // but still prevent users from depositing more than the `maxDepositShortDelay`,
       // only if buffer multiplier is set to 100%.
-      maxDeposit: bufferedMaxDepositShortDelay.toString(),
+      maxDeposit:
+        limitsBufferMultiplier.eq(ethers.utils.parseEther("1")) &&
+        !routeInvolvesLiteChain
+          ? liquidReserves.toString()
+          : bufferedMaxDepositShortDelay.toString(),
       maxDepositInstant: bufferedMaxDepositInstant.toString(),
       maxDepositShortDelay: bufferedMaxDepositShortDelay.toString(),
       recommendedDepositInstant: bufferedRecommendedDepositInstant.toString(),

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -1,4 +1,4 @@
-import { utils as sdkUtils } from "@across-protocol/sdk";
+import * as sdk from "@across-protocol/sdk";
 import { VercelResponse } from "@vercel/node";
 import { ethers } from "ethers";
 import {
@@ -9,23 +9,25 @@ import { TypedVercelRequest } from "./_types";
 import { object, assert, Infer, optional } from "superstruct";
 
 import {
-  getLogger,
-  getRelayerFeeDetails,
-  getCachedTokenPrice,
+  ENABLED_ROUTES,
+  HUB_POOL_CHAIN_ID,
+  callViaMulticall3,
   getCachedTokenBalance,
-  maxBN,
-  minBN,
-  handleErrorCondition,
-  validAddress,
-  positiveIntStr,
+  getCachedTokenPrice,
+  getDefaultRelayerAddress,
+  getHubPool,
+  getLimitsBufferMultiplier,
+  getLogger,
   getLpCushion,
   getProvider,
-  HUB_POOL_CHAIN_ID,
-  getDefaultRelayerAddress,
+  getRelayerFeeDetails,
+  handleErrorCondition,
+  maxBN,
+  minBN,
+  positiveIntStr,
   sendResponse,
-  getHubPool,
+  validAddress,
   validateChainAndTokenParams,
-  getLimitsBufferMultiplier,
 } from "./_utils";
 
 const LimitsQueryParamsSchema = object({
@@ -88,16 +90,32 @@ const handler = async (
     } = validateChainAndTokenParams(query);
 
     const hubPool = getHubPool(provider);
+    const configStoreClient = new sdk.contracts.acrossConfigStore.Client(
+      ENABLED_ROUTES.acrossConfigStoreAddress,
+      provider
+    );
+    const liteChainsKey =
+      sdk.clients.GLOBAL_CONFIG_STORE_KEYS.LITE_CHAIN_ID_INDICES;
+    const encodedLiteChainsKey = sdk.utils.utf8ToHex(liteChainsKey);
 
-    const multicallInput = [
-      hubPool.interface.encodeFunctionData("sync", [l1Token.address]),
-      hubPool.interface.encodeFunctionData("pooledTokens", [l1Token.address]),
+    const multiCalls = [
+      { contract: hubPool, functionName: "sync", args: [l1Token.address] },
+      {
+        contract: hubPool,
+        functionName: "pooledTokens",
+        args: [l1Token.address],
+      },
+      {
+        contract: configStoreClient.contract,
+        functionName: "globalConfig",
+        args: [encodedLiteChainsKey],
+      },
     ];
 
     const [tokenPriceNative, _tokenPriceUsd] = await Promise.all([
       getCachedTokenPrice(
         l1Token.address,
-        sdkUtils.getNativeTokenSymbol(destinationChainId).toLowerCase()
+        sdk.utils.getNativeTokenSymbol(destinationChainId).toLowerCase()
       ),
       getCachedTokenPrice(l1Token.address, "usd"),
     ]);
@@ -121,7 +139,7 @@ const handler = async (
         undefined,
         getDefaultRelayerAddress(destinationChainId, l1Token.symbol)
       ),
-      hubPool.callStatic.multicall(multicallInput, { blockTag: BLOCK_TAG_LAG }),
+      callViaMulticall3(provider, multiCalls, { blockTag: BLOCK_TAG_LAG }),
       Promise.all(
         fullRelayers.map((relayer) =>
           getCachedTokenBalance(
@@ -149,17 +167,16 @@ const handler = async (
       ),
     ]);
 
-    let { liquidReserves } = hubPool.interface.decodeFunctionResult(
-      "pooledTokens",
-      multicallOutput[1]
-    );
+    const [liteChainIdsEncoded] = multicallOutput[2];
+    const liteChainIds = JSON.parse(liteChainIdsEncoded);
+    const routeInvolvesLiteChain = [
+      computedOriginChainId,
+      destinationChainId,
+    ].some((chain) => liteChainIds.includes(chain));
 
-    const lpCushion = ethers.utils.parseUnits(
-      getLpCushion(l1Token.symbol, computedOriginChainId, destinationChainId),
-      l1Token.decimals
+    const transferBalances = fullRelayerBalances.map((balance, i) =>
+      balance.add(fullRelayerMainnetBalances[i])
     );
-    liquidReserves = liquidReserves.sub(lpCushion);
-    if (liquidReserves.lt(0)) liquidReserves = ethers.BigNumber.from(0);
 
     const minDeposit = ethers.BigNumber.from(relayerFeeDetails.minDeposit);
 
@@ -173,41 +190,58 @@ const handler = async (
           )
           .mul(ethers.utils.parseUnits("1"))
           .div(tokenPriceUsd);
+    
+    let maxDepositInstant = maxBN(
+      ...fullRelayerBalances,
+      ...transferRestrictedBalances
+    ); // balances on destination chain
 
-    const transferBalances = fullRelayerBalances.map((balance, i) =>
-      balance.add(fullRelayerMainnetBalances[i])
-    );
+    // Same as above.
+    let maxDepositShortDelay = maxBN(
+      ...transferBalances,
+      ...transferRestrictedBalances
+    ); // balances on destination chain + mainnet
 
-    const maxDepositInstant = minBN(
-      maxBN(...fullRelayerBalances, ...transferRestrictedBalances), // balances on destination chain
-      liquidReserves
-    );
-    const maxDepositShortDelay = minBN(
-      maxBN(...transferBalances, ...transferRestrictedBalances), // balances on destination chain + mainnet
-      liquidReserves
-    );
+    if (!routeInvolvesLiteChain) {
+      let { liquidReserves } = multicallOutput[1];
+
+      const lpCushion = ethers.utils.parseUnits(
+        getLpCushion(l1Token.symbol, computedOriginChainId, destinationChainId),
+        l1Token.decimals
+      );
+      liquidReserves = liquidReserves.sub(lpCushion);
+      if (liquidReserves.lt(0)) liquidReserves = ethers.BigNumber.from(0);
+
+      maxDepositInstant = minBN(maxDepositInstant, liquidReserves);
+      maxDepositShortDelay = minBN(maxDepositShortDelay, liquidReserves);
+    }
+
     const limitsBufferMultiplier = getLimitsBufferMultiplier(l1Token.symbol);
+    
+    // Apply multipliers
+    const bufferedRecommendedDepositInstant =
+    limitsBufferMultiplier
+      .mul(maxDepositInstant)
+      .div(sdk.utils.fixedPointAdjustment);
+    const bufferedMaxDepositInstant = limitsBufferMultiplier
+      .mul(maxDepositInstant)
+      .div(sdk.utils.fixedPointAdjustment);
     const bufferedMaxDepositShortDelay = limitsBufferMultiplier
-      .mul(maxDepositShortDelay)
-      .div(sdkUtils.fixedPointAdjustment)
-      .toString();
+    .mul(maxDepositShortDelay)
+    .div(sdk.utils.fixedPointAdjustment);
+
     const responseJson = {
       // Absolute minimum may be overridden by the environment.
       minDeposit: maxBN(minDeposit, minDepositFloor).toString(),
       // We set `maxDeposit` equal to `maxDepositShortDelay` to be backwards compatible
       // but still prevent users from depositing more than the `maxDepositShortDelay`,
       // only if buffer multiplier is set to 100%.
-      maxDeposit: limitsBufferMultiplier.eq(ethers.utils.parseEther("1"))
-        ? liquidReserves.toString()
-        : bufferedMaxDepositShortDelay,
-      maxDepositInstant: limitsBufferMultiplier
-        .mul(maxDepositInstant)
-        .div(sdkUtils.fixedPointAdjustment)
+      maxDeposit: bufferedMaxDepositShortDelay.toString(),
+      maxDepositInstant: bufferedMaxDepositInstant
         .toString(),
-      maxDepositShortDelay: bufferedMaxDepositShortDelay,
-      recommendedDepositInstant: limitsBufferMultiplier
-        .mul(maxDepositInstant)
-        .div(sdkUtils.fixedPointAdjustment)
+      maxDepositShortDelay: bufferedMaxDepositShortDelay
+        .toString(),
+      recommendedDepositInstant:bufferedRecommendedDepositInstant
         .toString(),
     };
     logger.debug({

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -167,6 +167,7 @@ const handler = async (
       ),
     ]);
 
+    let { liquidReserves } = multicallOutput[1];
     const [liteChainIdsEncoded] = multicallOutput[2];
     const liteChainIds = JSON.parse(liteChainIdsEncoded);
     const routeInvolvesLiteChain = [
@@ -203,8 +204,6 @@ const handler = async (
     ); // balances on destination chain + mainnet
 
     if (!routeInvolvesLiteChain) {
-      let { liquidReserves } = multicallOutput[1];
-
       const lpCushion = ethers.utils.parseUnits(
         getLpCushion(l1Token.symbol, computedOriginChainId, destinationChainId),
         l1Token.decimals

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -239,7 +239,8 @@ const handler = async (
       sdk.contracts.acrossConfigStore.Client.parseL1TokenConfig(
         String(rawL1TokenConfig)
       );
-    const liteChainIds = JSON.parse(liteChainIdsEncoded);
+    const liteChainIds =
+      liteChainIdsEncoded === "" ? [] : JSON.parse(liteChainIdsEncoded);
     const originChainIsLiteChain = liteChainIds.includes(computedOriginChainId);
     // We enforce repayment on the origin chain for lite chain deposits
     // so we overwrite the key to get the right rate model

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -170,6 +170,9 @@ const handler = async (
       ENABLED_ROUTES.acrossConfigStoreAddress,
       provider
     );
+    const liteChainsKey =
+      sdk.clients.GLOBAL_CONFIG_STORE_KEYS.LITE_CHAIN_ID_INDICES;
+    const encodedLiteChainsKey = sdk.utils.utf8ToHex(liteChainsKey);
 
     const baseCurrency = destinationChainId === 137 ? "matic" : "eth";
 
@@ -195,10 +198,21 @@ const handler = async (
         functionName: "l1TokenConfig",
         args: [l1Token.address],
       },
+      {
+        contract: configStoreClient.contract,
+        functionName: "globalConfig",
+        args: [encodedLiteChainsKey],
+      },
     ];
 
     const [
-      [currentUt, nextUt, quoteTimestamp, rawL1TokenConfig],
+      [
+        currentUt,
+        nextUt,
+        quoteTimestamp,
+        rawL1TokenConfig,
+        [liteChainIdsEncoded],
+      ],
       tokenPrice,
       limits,
     ] = await Promise.all([
@@ -225,7 +239,13 @@ const handler = async (
       sdk.contracts.acrossConfigStore.Client.parseL1TokenConfig(
         String(rawL1TokenConfig)
       );
-    const routeRateModelKey = `${computedOriginChainId}-${destinationChainId}`;
+    const liteChainIds = JSON.parse(liteChainIdsEncoded);
+    const originChainIsLiteChain = liteChainIds.includes(computedOriginChainId);
+    // We enforce repayment on the origin chain for lite chain deposits
+    // so we overwrite the key to get the right rate model
+    const routeRateModelKey = originChainIsLiteChain
+      ? `${computedOriginChainId}-${computedOriginChainId}`
+      : `${computedOriginChainId}-${destinationChainId}`;
     const rateModel =
       parsedL1TokenConfig.routeRateModel?.[routeRateModelKey] ||
       parsedL1TokenConfig.rateModel;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.0.1",
     "@across-protocol/contracts": "^3.0.1",
-    "@across-protocol/sdk": "^3.0.1",
+    "@across-protocol/sdk": "^3.1.0",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "1.1.6-beta.16",
     "@emotion/react": "^11.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.0.1.tgz#d1f1c44f8a33fae1db9fc926029b0ae2ce4206d5"
-  integrity sha512-QLP33AlveeDZxJLDWUy/COL+cGsFfAgDxmaI6eH9fA32tQ9/bJIchT9jnB8tD00V7Wnc5VoK8wC1C1nUUfpbhw==
+"@across-protocol/sdk@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.0.tgz#dd60da2824a72f5e70bb4d2cef9694b1df368385"
+  integrity sha512-CcSHaT7fqbRArsGgyjOxQRnNY+V7ft0Tsgmay/bITVjNfIit/oq3BpfStRa8M4PQ1wfQe78O5utSFCt4BygBjw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.0.1"


### PR DESCRIPTION
Required changes in /limits and /suggested-fees endpoints to support Across Lite.

/limits: when the requested route involves a lite chain, we avoid including the LP balances when defining limits.
/suggested-fees: the LP fee must be 0 when a route involves a lite chain. To achieve that we conditionally overwrite the rate model key we query.