### PR TITLE
fix(limits): set `maxDeposit` equal to `maxDepositShortDelay`

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -191,18 +191,21 @@ const handler = async (
       computedOriginChainId,
       destinationChainId
     );
+    const bufferedMaxDepositShortDelay = bufferMultipliers.depositShortDelay
+      .mul(maxDepositShortDelay)
+      .div(sdkUtils.fixedPointAdjustment)
+      .toString();
     const responseJson = {
       // Absolute minimum may be overridden by the environment.
       minDeposit: maxBN(minDeposit, minDepositFloor).toString(),
-      maxDeposit: liquidReserves.toString(),
+      // We set `maxDeposit` equal to `maxDepositShortDelay` to be backwards compatible
+      // but still prevent users from depositing more than the `maxDepositShortDelay`.
+      maxDeposit: bufferedMaxDepositShortDelay,
       maxDepositInstant: bufferMultipliers.depositInstant
         .mul(maxDepositInstant)
         .div(sdkUtils.fixedPointAdjustment)
         .toString(),
-      maxDepositShortDelay: bufferMultipliers.depositShortDelay
-        .mul(maxDepositShortDelay)
-        .div(sdkUtils.fixedPointAdjustment)
-        .toString(),
+      maxDepositShortDelay: bufferedMaxDepositShortDelay,
       recommendedDepositInstant: bufferMultipliers.recommendedDepositInstant
         .mul(maxDepositInstant)
         .div(sdkUtils.fixedPointAdjustment)


### PR DESCRIPTION
Since we no longer provide fees if the amount > maxDepositShortDelay, but still have `maxDeposit` in the response body of `/limits`, integrators got confused. To prevent this, we set now `maxDeposit` to the same value as `maxDepositShortDelay`