### PR TITLE
feat(liquidReserves): Add liquid-reserves endpoint that relayers can use

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -373,7 +373,15 @@ export const getRouteDetails = (
   };
 };
 
-export const getTokenByAddress = (tokenAddress: string, chainId?: number) => {
+export const getTokenByAddress = (
+  tokenAddress: string,
+  chainId?: number
+): {
+  decimals: number;
+  symbol: string;
+  name: string;
+  addresses: Record<number, string>;
+} => {
   const matches =
     Object.entries(TOKEN_SYMBOLS_MAP).filter(([_symbol, { addresses }]) =>
       chainId

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -376,12 +376,14 @@ export const getRouteDetails = (
 export const getTokenByAddress = (
   tokenAddress: string,
   chainId?: number
-): {
-  decimals: number;
-  symbol: string;
-  name: string;
-  addresses: Record<number, string>;
-} => {
+):
+  | {
+      decimals: number;
+      symbol: string;
+      name: string;
+      addresses: Record<number, string>;
+    }
+  | undefined => {
   const matches =
     Object.entries(TOKEN_SYMBOLS_MAP).filter(([_symbol, { addresses }]) =>
       chainId

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -74,15 +74,17 @@ const handler = async (
       }),
     ];
 
-    const [multicallOutput] = await Promise.all([
+    const [multicallOutput, ...lpCushions] = await Promise.all([
       callViaMulticall3(provider, multiCalls, { blockTag: BLOCK_TAG_LAG }),
+      ...l1TokenDetails.map((_l1Token) =>
+        Promise.resolve(
+          ethers.utils.parseUnits(
+            getLpCushion(_l1Token!.symbol),
+            _l1Token!.decimals
+          )
+        )
+      ),
     ]);
-    const lpCushions = l1TokenDetails.map((_l1Token) =>
-      ethers.utils.parseUnits(
-        getLpCushion(_l1Token!.symbol),
-        _l1Token!.decimals
-      )
-    );
     const liquidReservesForL1Tokens = multicallOutput.slice(
       parsedL1Tokens.length
     );

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -61,15 +61,17 @@ const handler = async (
       },
     ];
 
-    const [multicallOutput] = await Promise.all([
+    const [multicallOutput, lpCushion] = await Promise.all([
       callViaMulticall3(provider, multiCalls, { blockTag: BLOCK_TAG_LAG }),
+      Promise.resolve(
+        ethers.utils.parseUnits(
+          getLpCushion(l1TokenDetails.symbol),
+          l1TokenDetails.decimals
+        )
+      ),
     ]);
 
     const { liquidReserves } = multicallOutput[1];
-    const lpCushion = ethers.utils.parseUnits(
-      getLpCushion(l1TokenDetails.symbol),
-      l1TokenDetails.decimals
-    );
     const liquidReservesWithCushion = liquidReserves.sub(lpCushion);
 
     const responseJson = {

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -85,10 +85,11 @@ const handler = async (
         )
       ),
     ]);
+    const liquidReservesForL1Tokens = multicallOutput.slice(l1Tokens.length);
 
     const responses = Object.fromEntries(
       l1Tokens.map((l1Token, i) => {
-        const { liquidReserves } = multicallOutput[i * 2 + 1];
+        const { liquidReserves } = liquidReservesForL1Tokens[i];
         const lpCushion = lpCushions[i];
         const liquidReservesWithCushion = liquidReserves.sub(lpCushion);
         return [

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -85,15 +85,15 @@ const handler = async (
         )
       ),
     ]);
-    logger.debug({
-      at: "LiquidReserves",
-      message: "Test",
-      multicallOutput,
-      lpCushions,
-    });
     const liquidReservesForL1Tokens = multicallOutput.slice(
       parsedL1Tokens.length
     );
+    logger.debug({
+      at: "LiquidReserves",
+      message: "Test",
+      liquidReservesForL1Tokens,
+      lpCushions,
+    });
 
     const responses = Object.fromEntries(
       parsedL1Tokens.map((_l1Token, i) => {

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -92,14 +92,7 @@ const handler = async (
         const { liquidReserves } = liquidReservesForL1Tokens[i];
         const lpCushion = lpCushions[i];
         const liquidReservesWithCushion = liquidReserves.sub(lpCushion);
-        return [
-          l1Token,
-          {
-            liquidReserves,
-            lpCushion,
-            liquidReservesWithCushion,
-          },
-        ];
+        return [l1Token, liquidReservesWithCushion];
       })
     );
 

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -50,7 +50,7 @@ const handler = async (
     );
     if (!l1TokenDetails) {
       throw new InputError(
-        `Query contais an unsupported L1 token address: ${query.l1Tokens}`
+        `Query contains an unsupported L1 token address: ${query.l1Tokens}`
       );
     }
 

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -43,7 +43,14 @@ const handler = async (
   try {
     assert(query, LiquidReservesQueryParamsSchema);
     const { l1Tokens } = query;
-    const parsedL1Tokens = l1Tokens.split(",");
+    const parsedL1Tokens = l1Tokens
+      .split(",")
+      .filter((address) => ethers.utils.isAddress(address));
+    logger.debug({
+      at: "LiquidReserves",
+      message: "Test",
+      parsedL1Tokens,
+    });
 
     const l1TokenDetails = parsedL1Tokens.map((_l1Token) =>
       getTokenByAddress(_l1Token, HUB_POOL_CHAIN_ID)
@@ -88,12 +95,6 @@ const handler = async (
     const liquidReservesForL1Tokens = multicallOutput.slice(
       parsedL1Tokens.length
     );
-    logger.debug({
-      at: "LiquidReserves",
-      message: "Test",
-      liquidReservesForL1Tokens,
-      lpCushions,
-    });
 
     const responses = Object.fromEntries(
       parsedL1Tokens.map((_l1Token, i) => {

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -74,17 +74,15 @@ const handler = async (
       }),
     ];
 
-    const [multicallOutput, ...lpCushions] = await Promise.all([
+    const [multicallOutput] = await Promise.all([
       callViaMulticall3(provider, multiCalls, { blockTag: BLOCK_TAG_LAG }),
-      Promise.resolve(
-        l1TokenDetails.map((_l1Token) =>
-          ethers.utils.parseUnits(
-            getLpCushion(_l1Token!.symbol),
-            _l1Token!.decimals
-          )
-        )
-      ),
     ]);
+    const lpCushions = l1TokenDetails.map((_l1Token) =>
+      ethers.utils.parseUnits(
+        getLpCushion(_l1Token!.symbol),
+        _l1Token!.decimals
+      )
+    );
     const liquidReservesForL1Tokens = multicallOutput.slice(
       parsedL1Tokens.length
     );

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -92,7 +92,7 @@ const handler = async (
         const { liquidReserves } = liquidReservesForL1Tokens[i];
         const lpCushion = lpCushions[i];
         const liquidReservesWithCushion = liquidReserves.sub(lpCushion);
-        return [l1Token, liquidReservesWithCushion];
+        return [l1Token, liquidReservesWithCushion.toString()];
       })
     );
 

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -48,7 +48,7 @@ const handler = async (
       .filter((address) => ethers.utils.isAddress(address));
     logger.debug({
       at: "LiquidReserves",
-      message: "Test",
+      message: "Parsed L1 tokens",
       parsedL1Tokens,
     });
 
@@ -110,9 +110,9 @@ const handler = async (
       message: "Response data",
       responses,
     });
-    // Respond with a 200 status code and 7 minutes of cache with
+    // Respond with a 200 status code and 4 minutes of cache with
     // a minute of stale-while-revalidate.
-    sendResponse(response, responses, 200, 420, 60);
+    sendResponse(response, responses, 200, 240, 60);
   } catch (error: unknown) {
     return handleErrorCondition("liquidReserves", response, logger, error);
   }

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -1,0 +1,95 @@
+import { VercelResponse } from "@vercel/node";
+import { ethers } from "ethers";
+import { BLOCK_TAG_LAG } from "./_constants";
+import { TypedVercelRequest } from "./_types";
+import { object, assert, Infer } from "superstruct";
+
+import {
+  HUB_POOL_CHAIN_ID,
+  InputError,
+  callViaMulticall3,
+  getHubPool,
+  getLogger,
+  getLpCushion,
+  getProvider,
+  getTokenByAddress,
+  handleErrorCondition,
+  positiveIntStr,
+  sendResponse,
+  validAddress,
+} from "./_utils";
+
+const LiquidReservesQueryParamsSchema = object({
+  l1Token: validAddress(),
+  originChainId: positiveIntStr(),
+});
+
+type LiquidReservesQueryParamsSchema = Infer<
+  typeof LiquidReservesQueryParamsSchema
+>;
+
+// Returns the HubPool liquid reserves minus the LP cushion. Useful for relayers to query so that they don't
+// fill deposits that would overcommit the reserves.
+const handler = async (
+  { query }: TypedVercelRequest<LiquidReservesQueryParamsSchema>,
+  response: VercelResponse
+) => {
+  const logger = getLogger();
+  logger.debug({
+    at: "LiquidReserves",
+    message: "Query data",
+    query,
+  });
+  try {
+    assert(query, LiquidReservesQueryParamsSchema);
+    const { l1Token, originChainId } = query;
+
+    const l1TokenDetails = getTokenByAddress(query.l1Token, HUB_POOL_CHAIN_ID);
+    if (!l1TokenDetails) {
+      throw new InputError(`Unsupported L1 token address: ${query.l1Token}`);
+    }
+    if (!originChainId) {
+      throw new InputError("Query param 'originChainId' must be provided");
+    }
+
+    const provider = getProvider(HUB_POOL_CHAIN_ID);
+    const hubPool = getHubPool(provider);
+    const multiCalls = [
+      { contract: hubPool, functionName: "sync", args: [l1Token] },
+      {
+        contract: hubPool,
+        functionName: "pooledTokens",
+        args: [l1Token],
+      },
+    ];
+
+    const [multicallOutput] = await Promise.all([
+      callViaMulticall3(provider, multiCalls, { blockTag: BLOCK_TAG_LAG }),
+    ]);
+
+    const { liquidReserves } = multicallOutput[1];
+    const lpCushion = ethers.utils.parseUnits(
+      getLpCushion(l1TokenDetails.symbol, Number(originChainId)),
+      l1TokenDetails.decimals
+    );
+    const liquidReservesWithCushion = liquidReserves.sub(lpCushion);
+
+    const responseJson = {
+      liquidReserves: liquidReserves.toString(),
+      lpCushion: lpCushion.toString(),
+      liquidReservesWithCushion: liquidReservesWithCushion.toString(),
+    };
+    logger.debug({
+      at: "LiquidReserves",
+      message: "Response data",
+      responseJson,
+    });
+    // Respond with a 200 status code and 7 minutes of cache with
+    // a minute of stale-while-revalidate.
+    sendResponse(response, responseJson, 200, 420, 60);
+  } catch (error: unknown) {
+    return handleErrorCondition("liquidReserves", response, logger, error);
+  }
+};
+
+export default handler;

--- a/api/liquid-reserves.ts
+++ b/api/liquid-reserves.ts
@@ -45,8 +45,8 @@ const handler = async (
     assert(query, LiquidReservesQueryParamsSchema);
     const { l1Token } = query;
 
-    const l1TokenDetails = query.l1Token.map((l1Token) =>
-      getTokenByAddress(l1Token, HUB_POOL_CHAIN_ID)
+    const l1TokenDetails = query.l1Token.map((_l1Token) =>
+      getTokenByAddress(_l1Token, HUB_POOL_CHAIN_ID)
     );
     if (!l1TokenDetails) {
       throw new InputError(
@@ -69,7 +69,7 @@ const handler = async (
         return {
           contract: hubPool,
           functionName: "pooledTokens",
-          args: [l1Token],
+          args: [_l1Token],
         };
       }),
     ];
@@ -77,10 +77,10 @@ const handler = async (
     const [multicallOutput, ...lpCushions] = await Promise.all([
       callViaMulticall3(provider, multiCalls, { blockTag: BLOCK_TAG_LAG }),
       Promise.resolve(
-        l1TokenDetails.map((l1Token) =>
+        l1TokenDetails.map((_l1Token) =>
           ethers.utils.parseUnits(
-            getLpCushion(l1Token!.symbol),
-            l1Token!.decimals
+            getLpCushion(_l1Token!.symbol),
+            _l1Token!.decimals
           )
         )
       ),


### PR DESCRIPTION
Currently relayers query /limits to figure out the `maxDeposit` they should fill, however `maxDeposit` currently applies a buffer which means the relayer can't fill any deposits that are larger than the `liquidReserves * buffer` but smaller than `liquidReserves`

Create a separate endpoint with a simpler interface (i.e. only need to define L1 token and origin chain ID and both are required params) to get limits for relayer. This should simplify the relayer code in the AcrossApiClient

Signed-off-by: nicholaspai <npai.nyc@gmail.com>